### PR TITLE
mongodb datasource template

### DIFF
--- a/api/schemas/templates/data-sources/mongodb.json
+++ b/api/schemas/templates/data-sources/mongodb.json
@@ -1,0 +1,42 @@
+{
+  "title": "MongodbDataSourceTemplate",
+  "description": "Create form for a Mongodb data-source",
+  "type": "object",
+  "properties": {
+    "type": {
+      "type": "string",
+      "title": "Type",
+      "default": "mongodb"
+    },
+    "host": {
+      "type": "string",
+      "title": "Hostname"
+    },
+    "port": {
+      "type": "integer",
+      "title": "port",
+      "default": 27017
+    },
+    "username": {
+      "type": "string",
+      "title": "Username"
+    },
+    "password": {
+      "type": "string",
+      "title": "Password"
+    },
+    "tls": {
+      "type": "boolean",
+      "title": "TLS",
+      "default": false
+    },
+    "database": {
+      "type": "string",
+      "title": "Database"
+    },
+    "collection": {
+      "type": "string",
+      "title": "Collection"
+    }
+  }
+}


### PR DESCRIPTION
## What does this pull request change?
Adds a compatible json-schema for a mongodb datasource.
Available at "localhost/api/templates/data-sources/mongodb.json" 
## Why is this pull request needed?

## Issues releated to this change:
