### PR TITLE
fix: Schemas are imported

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # data-modelling-tool
+
 [![Build Status](https://travis-ci.com/equinor/data-modelling-tool.svg?token=yR5pmi3sbtpmzTWwTfNG&branch=master)](https://travis-ci.com/equinor/data-modelling-tool)
 
 A tool for modelling and presenting on blue-prints (data models)
@@ -32,7 +33,7 @@ To populate the database for first-time-use, we will import all files in the `ap
 
 1. Start the project with `docker-compose up`
 2. Run the Flaks applications CLI command 'init-import' with;  
-   `docker-compose exec api flask init-import`
+   `docker-compose exec api ./reset-database.sh`
 
 ### Intellij Idea Plugin
 

--- a/api/app.py
+++ b/api/app.py
@@ -45,7 +45,7 @@ def init_import():
                     model_db[f"{collection}"].replace_one({"_id": id}, document, upsert=True)
 
 
-@app.cli.command("import_data_source")
+@app.cli.command()
 @click.argument("file")
 def import_data_source(file):
     print(f"Importing {file} as data_source with id: {id}.")

--- a/api/reset-database.sh
+++ b/api/reset-database.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env sh
 set -eu
 
+mkdir -p /code/schemas/documents/entities
+
 flask nuke-db
 flask init-import
+
+if [ "$ENVIRONMENT" = 'local' ]; then
+    echo "Populating database"
+    for dataSource in /code/schemas/data-sources/"${ENVIRONMENT}"-mongo-*.json ; do
+      flask import-data-source "$dataSource"
+    done
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     volumes:
       - ./api/:/code
     environment:
+      ENVIRONMENT: azure
       MONGO_INITDB_ROOT_USERNAME: maf
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_INITDB_ROOT_PASSWORD}
       MONGO_INITDB_DATABASE: maf

--- a/web/README.md
+++ b/web/README.md
@@ -2,6 +2,6 @@
 
 | Statements                                    | Branches                                  | Functions                                   | Lines                               |
 | --------------------------------------------- | ----------------------------------------- | ------------------------------------------- | ----------------------------------- |
-| ![Statements](https://img.shields.io/badge/Coverage-28.11%25-red.svg 'Make me better!') | ![Branches](https://img.shields.io/badge/Coverage-9.72%25-red.svg 'Make me better!') | ![Functions](https://img.shields.io/badge/Coverage-11.22%25-red.svg 'Make me better!') | ![Lines](https://img.shields.io/badge/Coverage-28.41%25-red.svg 'Make me better!') |
+| ![Statements](https://img.shields.io/badge/Coverage-28.06%25-red.svg 'Make me better!') | ![Branches](https://img.shields.io/badge/Coverage-9.72%25-red.svg 'Make me better!') | ![Functions](https://img.shields.io/badge/Coverage-11.22%25-red.svg 'Make me better!') | ![Lines](https://img.shields.io/badge/Coverage-28.36%25-red.svg 'Make me better!') |
 
 ## Web


### PR DESCRIPTION
## What does this pull request change?
* Sets the `ENVIRNOMENT` variable to `azure` in `docker-compose.yml`
  * This makes the `reset-database/sh` script more flexible
* The blueprints and entities where not imported
* The documentation of how to setup a local development environment was outdated, with regards to the database
* The folder `schemas/documents/entities` is kept, even though it is empty

## Why is this pull request needed?
96b1d71f01090da94f2581b8d9eacf1116fe81e2 introduced a new command for importing blueprints, and entities, but did not update the reset script.

Additionally, the documentation in README.md, was outdated regarding how to setup / initialise the database.

The folder `schemas/documents/entities` is required for resetting the database, even though it is empty.