### PR TITLE
web: add fileupload to datasources modal

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -2,6 +2,6 @@
 
 | Statements                                    | Branches                                  | Functions                                   | Lines                               |
 | --------------------------------------------- | ----------------------------------------- | ------------------------------------------- | ----------------------------------- |
-| ![Statements](https://img.shields.io/badge/Coverage-27.54%25-red.svg 'Make me better!') | ![Branches](https://img.shields.io/badge/Coverage-8.93%25-red.svg 'Make me better!') | ![Functions](https://img.shields.io/badge/Coverage-10.75%25-red.svg 'Make me better!') | ![Lines](https://img.shields.io/badge/Coverage-27.83%25-red.svg 'Make me better!') |
+| ![Statements](https://img.shields.io/badge/Coverage-27.4%25-red.svg 'Make me better!') | ![Branches](https://img.shields.io/badge/Coverage-8.93%25-red.svg 'Make me better!') | ![Functions](https://img.shields.io/badge/Coverage-10.7%25-red.svg 'Make me better!') | ![Lines](https://img.shields.io/badge/Coverage-27.68%25-red.svg 'Make me better!') |
 
 ## Web

--- a/web/src/api/Api.ts
+++ b/web/src/api/Api.ts
@@ -6,7 +6,7 @@ export class DmtApi {
     return `/api/data-sources/${datasourceId}`
   }
   dataSourcesPost() {
-    return `/api/data-sources`
+    return `/api/data-sources/blueprints`
   }
 
   indexGet(datasourceId: string) {
@@ -60,5 +60,6 @@ export type IndexNode = {
   versions: string[]
   nodeType: 'folder' | 'file'
   isRoot: boolean
+  isOpen?: boolean
   children?: string[]
 }

--- a/web/src/pages/blueprints/BlueprintsPage.tsx
+++ b/web/src/pages/blueprints/BlueprintsPage.tsx
@@ -46,7 +46,11 @@ export default () => {
     if (!state.dataSources.length) {
       axios(api.dataSourcesGet(DataSourceType.Blueprints))
         .then((res: any) => {
-          dispatch(DocumentActions.addDatasources(res.data))
+          dispatch(
+            DocumentActions.addDatasources(
+              res.data.filter((d: Datasource) => d.host === 'db')
+            )
+          )
         })
         .catch((e: any) => {
           console.log(e)

--- a/web/src/pages/blueprints/Header.tsx
+++ b/web/src/pages/blueprints/Header.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { DocumentsAction, DocumentsState } from '../common/DocumentReducer'
 import Header from '../../components/Header'
-import FileUpload from '../common/tree-view/FileUpload'
 import { Col, Grid, Row } from 'react-styled-flexboxgrid'
 import AddDatasource from '../common/tree-view/AddDatasource'
 
@@ -11,8 +10,6 @@ type Props = {
 }
 
 export default (props: Props) => {
-  const { state, dispatch } = props
-
   return (
     <Grid fluid>
       <Row
@@ -22,9 +19,7 @@ export default (props: Props) => {
           marginBottom: 20,
         }}
       >
-        <Col style={{ display: 'inline-flex', marginBottom: 20 }}>
-          {false && <FileUpload state={state} dispatch={dispatch} />}
-        </Col>
+        <Col style={{ display: 'inline-flex', marginBottom: 20 }}></Col>
 
         <Col style={{ display: 'inline-flex', marginBottom: 20 }}>
           <AddDatasource {...props} />

--- a/web/src/pages/common/tree-view/AddDatasource.tsx
+++ b/web/src/pages/common/tree-view/AddDatasource.tsx
@@ -6,10 +6,11 @@ import Modal from '../../../components/modal/Modal'
 //@ts-ignore
 import { NotificationManager } from 'react-notifications'
 import { DmtApi } from '../../../api/Api'
-// import {EntitiesActions} from "../EntitiesReducer";
+import FileUpload from './FileUpload'
 const api = new DmtApi()
 const datasourcesOptions = [
   { label: '', templateUrl: '' },
+  { label: 'local files', templateUrl: '' },
   {
     fetchSchema: api.templatesDatasourceMongoGet(),
     label: 'mongo db',
@@ -17,7 +18,7 @@ const datasourcesOptions = [
 ]
 
 export default (props: any) => {
-  // const { state, dispatch } = props
+  const { state, dispatch } = props
   const [showModal, setShowModal] = useState(false)
   const [selectedTemplate, setSelectedTemplate] = useState(0)
 
@@ -48,6 +49,7 @@ export default (props: any) => {
             schemaUrl={api.templatesDatasourceMongoGet()}
             dataUrl=""
             onSubmit={formData => {
+              console.log(formData)
               axios
                 .post(api.dataSourcesPost(), formData)
                 .then((res: any) => {
@@ -64,6 +66,9 @@ export default (props: any) => {
                 })
             }}
           />
+        )}
+        {selectedTemplate === 1 && (
+          <FileUpload state={state} dispatch={dispatch} />
         )}
       </Modal>
       <div style={{ fontWeight: 700, marginLeft: 10, marginBottom: 10 }}>

--- a/web/src/pages/common/tree-view/FileUpload.tsx
+++ b/web/src/pages/common/tree-view/FileUpload.tsx
@@ -32,9 +32,11 @@ export default (props: Props) => {
         }
         index.push(indexItem)
 
+        console.log(path, json)
+
         //hack to deal with async behavior fileReader.
         if (index.length === numFiles) {
-          console.log('dispatch: ', index.length, numFiles)
+          console.log('dispatch: ', index)
           // dispatch(DocumentActions.setSelectedDataSourceId(path))
         }
         // if (postToApi) {


### PR DESCRIPTION
## What does this pull request change?
Adds fileupload to datasources modal
The file paths and the content is logged to console after upload. 
Need and api endpoint to pass these files to and get index in response. 

## Why is this pull request needed?
User should be able to upload files. 

## Issues releated to this change:
