### PR TITLE
Added endpoint for adding an index

### DIFF
--- a/api/classes/data_source.py
+++ b/api/classes/data_source.py
@@ -11,7 +11,28 @@ def get_data_source_from_database(_id):
     return data_source
 
 
+class MockClient:
+    def __init__(self, data):
+        self._data = data
+
+    def get_root_packages(self):
+        return [item for item in self._data if ("documentType" in item and item["documentType"] == "root-package")]
+
+    def read_form(self, package_name):
+        for item in self._data:
+            _id = item.get("_id", item.get("id"))
+            if _id == package_name:
+                return item
+        return None
+
+
 class DataSource:
+    @classmethod
+    def mock(cls, data):
+        inst = cls.__new__(cls)
+        inst.client = MockClient(data)
+        return inst
+
     def __init__(self, _id: str):
         # TODO: Auth
         data_source_dict = get_data_source_from_database(_id)

--- a/api/rest/data_source_consumers/index.py
+++ b/api/rest/data_source_consumers/index.py
@@ -1,3 +1,4 @@
+from flask import request
 from flask_restful import Resource
 
 from classes.data_source import DataSource
@@ -64,3 +65,9 @@ class Index(Resource):
         data_source = DataSource(data_source_id)
         test = index_data_source(data_source=data_source)
         return test
+
+    @staticmethod
+    def post(data_source_id):
+        data = request.get_json()
+        data_source = DataSource.mock([{**item["content"], "_id": item["id"]} for item in data])
+        return index_data_source(data_source)

--- a/web/src/api/Api.ts
+++ b/web/src/api/Api.ts
@@ -13,6 +13,10 @@ export class DmtApi {
     return `/api/index/${datasourceId}`
   }
 
+  indexPost(dataSourceId: string): string {
+    return `/api/index/${dataSourceId}`
+  }
+
   templatesDatasourceMongoGet() {
     return `/api/templates/data-sources/mongodb.json`
   }

--- a/web/src/pages/common/tree-view/FileUpload.tsx
+++ b/web/src/pages/common/tree-view/FileUpload.tsx
@@ -1,9 +1,13 @@
 import React from 'react'
 import { DocumentsState } from '../DocumentReducer'
+import axios from 'axios'
+import { DmtApi } from '../../../api/Api'
 
-type IndexItem = {
-  _id: string
-  title: string
+const api = new DmtApi()
+
+type RequestBody = {
+  id: string
+  content: any
 }
 
 type Props = {
@@ -12,9 +16,7 @@ type Props = {
 }
 
 export default (props: Props) => {
-  // const { dispatch } = props
-
-  function handleFile(file: File, index: any[], numFiles: number) {
+  function handleFile(file: File, index: RequestBody[], numFiles: number) {
     let fileReader: FileReader
     fileReader = new FileReader()
     fileReader.onloadend = () => {
@@ -22,34 +24,21 @@ export default (props: Props) => {
       if (typeof content === 'string') {
         //@ts-ignore
         const relativePath = file.webkitRelativePath
-        const indexOfCurrent = relativePath.indexOf('/')
-        const path = relativePath.substring(indexOfCurrent + 1)
-        // const url = state.dataUrl + path
+        const path = `blueprints/${relativePath}`
         const json = JSON.parse(content)
         const indexItem = {
-          _id: path,
-          title: json.title,
+          id: path,
+          content: json,
         }
         index.push(indexItem)
-
-        console.log(path, json)
 
         //hack to deal with async behavior fileReader.
         if (index.length === numFiles) {
           console.log('dispatch: ', index)
-          // dispatch(DocumentActions.setSelectedDataSourceId(path))
+          axios.post(api.indexPost('local'), index).then(res => {
+            console.log('We have an index! ', res)
+          })
         }
-        // if (postToApi) {
-        //   axios
-        //     .put(url, JSON.parse(content))
-        //     .then(res => {
-        //       //@todo update treeview.
-        //       console.log('added to db: ', res)
-        //     })
-        //     .catch(e => {
-        //       console.log(e)
-        //     })
-        // }
       }
     }
     fileReader.readAsText(file)
@@ -57,7 +46,7 @@ export default (props: Props) => {
 
   const handleFiles = (e: any) => {
     const files: any = e.target.files
-    const index: IndexItem[] = []
+    const index: RequestBody[] = []
     for (let i = 0; i < files.length; i++) {
       //@todo use generateTreeview to validate the uploaded files.
       handleFile(files[i], index, files.length)


### PR DESCRIPTION
## What does this pull request change?
Adds an endpoint for getting an index from the API when importing / uploading a package.

**Note**: There is not interaction with the database as of now. The "uploaded" package will only be available to the local workspace (#126), by default.

Later dragging, and dropping will be implemented, so that a blueprint / entity can be created / edited locally before uploaded to a database.

## Why is this pull request needed?
See #115.
 

## Issues releated to this change:
#115 