### PR TITLE
web: use icon for file-import

### DIFF
--- a/web/src/pages/blueprints/BlueprintsPage.tsx
+++ b/web/src/pages/blueprints/BlueprintsPage.tsx
@@ -61,19 +61,23 @@ export default () => {
       <Row>
         <Col xs={12} md={12} lg={5}>
           <Wrapper>
-            <Header>
-              <div />
-              <AddDatasource />
-            </Header>
+            <div style={{ marginBottom: 25 }}>
+              <Header>
+                <div />
+                <AddDatasource />
+              </Header>
+            </div>
             {state.dataSources.map((ds: Datasource) => (
-              <div key={ds.id}>
+              <div key={ds.id} style={{ marginBottom: 30 }}>
                 <Header>
                   <H5>{ds.name}</H5>
-                  <FileUpload
-                    state={state}
-                    dispatch={dispatch}
-                    datasource={ds}
-                  />
+                  {ds.type === 'localStorage' && (
+                    <FileUpload
+                      state={state}
+                      dispatch={dispatch}
+                      datasource={ds}
+                    />
+                  )}
                 </Header>
                 <DocumentTree
                   onNodeSelect={(node: TreeNodeData) => {

--- a/web/src/pages/common/tree-view/FileUpload.tsx
+++ b/web/src/pages/common/tree-view/FileUpload.tsx
@@ -1,6 +1,10 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { DocumentsState } from '../DocumentReducer'
+//@ts-ignore
+import { NotificationManager } from 'react-notifications'
 import { Datasource, IndexApi, IndexRequestBody } from '../../../api/Api'
+import Modal from '../../../components/modal/Modal'
+import { FaUpload } from 'react-icons/fa'
 
 const api = new IndexApi()
 
@@ -12,6 +16,7 @@ type Props = {
 
 export default (props: Props) => {
   const { datasource } = props
+  const [open, setOpen] = useState(false)
 
   function handleFile(file: File, index: IndexRequestBody[], numFiles: number) {
     let fileReader: FileReader
@@ -29,9 +34,13 @@ export default (props: Props) => {
         }
         index.push(indexItem)
 
+        const onSuccess = () => {
+          NotificationManager.success('', `Uploaded ${numFiles} files.`)
+          setOpen(false)
+        }
         //hack to deal with async behavior fileReader.
         if (index.length === numFiles) {
-          api.post({ datasource, index })
+          api.post({ datasource, index, onSuccess })
         }
       }
     }
@@ -42,26 +51,32 @@ export default (props: Props) => {
     const files: any = e.target.files
     const index: IndexRequestBody[] = []
     for (let i = 0; i < files.length; i++) {
-      //@todo use generateTreeview to validate the uploaded files.
       handleFile(files[i], index, files.length)
     }
   }
 
   return (
     <div style={{ margin: 'auto' }}>
-      <div style={{ fontWeight: 700 }}>Upload blueprints at root: </div>
-      <div>
-        {
-          //@ts-ignore
-          <input
-            type="file"
-            webkitdirectory="true"
-            mozdirectory="true"
-            directory="true"
-            onChange={handleFiles}
-          />
-        }
-      </div>
+      <FaUpload
+        onClick={() => {
+          setOpen(true)
+        }}
+      />
+      <Modal open={open} toggle={() => setOpen(!open)}>
+        <div style={{ fontWeight: 700 }}>Upload blueprints at root: </div>
+        <div>
+          {
+            //@ts-ignore
+            <input
+              type="file"
+              webkitdirectory="true"
+              mozdirectory="true"
+              directory="true"
+              onChange={handleFiles}
+            />
+          }
+        </div>
+      </Modal>
     </div>
   )
 }


### PR DESCRIPTION
## What does this pull request change?
wrap file upload ui stuff in a modal, open by clicking on a icon

## Why is this pull request needed?
Simplify ui

## Issues releated to this change:
