### PR TITLE
fix: update endpoints for create datasource. Update api in web

### DIFF
--- a/api/classes/data_source.py
+++ b/api/classes/data_source.py
@@ -49,7 +49,7 @@ class DataSource:
         self.collection = data_source_dict["collection"]
         self.documentType = data_source_dict["documentType"]
 
-        if self.type == "mongodb":
+        if self.type == "mongo-db":
             self.client = MongodbClient(
                 host=self.host,
                 port=self.port,

--- a/api/rest/__init__.py
+++ b/api/rest/__init__.py
@@ -4,7 +4,7 @@ from rest.data_source_consumers.document import Document
 from rest.data_source_consumers.document_with_template import DocumentWithTemplate
 from rest.data_source_consumers.index import Index
 from rest.data_source_consumers.packages import Packages
-from rest.data_sources import DataSources, SingleDataSource
+from rest.data_sources import SingleDataSource
 from rest.template import Template
 
 
@@ -21,7 +21,7 @@ def create_api(app):
     api.add_resource(Index, "/api/index/<string:data_source_id>")
 
     # Get a list of all data-sources
-    api.add_resource(DataSources, "/api/data-sources/<string:document_type>")
+    # api.add_resource(DataSources, "/api/data-sources/<string:document_type>")
 
     # Get and Update a single document
     api.add_resource(Document, "/api/data-sources/<string:data_source_id>/<path:form_id>")
@@ -30,7 +30,7 @@ def create_api(app):
     api.add_resource(Template, "/api/templates/<path:id>")
 
     # Create, update, or delete a data-source
-    api.add_resource(SingleDataSource, "/api/data-sources/<string:id>")
+    api.add_resource(SingleDataSource, "/api/data-sources/<string:id>", "/api/data-sources")
 
     # Not currently used by front end
     # api.add_resource(Transformer, "/api/transformer/json-schema")

--- a/api/rest/data_sources.py
+++ b/api/rest/data_sources.py
@@ -18,11 +18,10 @@ def data_sources_get(document_type: str):
     return all_sources
 
 
-def data_source_post(document_type):
+def data_source_post(id):
     document = request.get_json()
     validate_mongo_data_source(document)
-    document["documentType"] = document_type
-    document["_id"] = document["name"]
+    document["_id"] = id
     logger.info(f"Inserting new data-source with id {document['_id']}.")
     result = collection.insert_one(document)
     logger.info(f"Successfully inserted with id {result}")
@@ -44,22 +43,17 @@ def data_source_delete(id):
 class SingleDataSource(Resource):
     @staticmethod
     def post(id):
-        return data_source_put(id=id)
+        return data_source_post(id)
 
     @staticmethod
     def put(id):
-        return data_source_put(id=id)
+        return data_source_put(id)
 
     @staticmethod
     def delete(id):
-        return data_source_delete(id=id)
+        return data_source_delete(id)
 
-
-class DataSources(Resource):
     @staticmethod
-    def get(document_type):
+    def get():
+        document_type = request.args["documentType"]
         return data_sources_get(document_type)
-
-    @staticmethod
-    def post(document_type):
-        return data_source_post(document_type)

--- a/api/rest/validators/mongo_data_source.py
+++ b/api/rest/validators/mongo_data_source.py
@@ -9,6 +9,6 @@ def validate_mongo_data_source(document):
     # TODO: Update requirements on schema
     schema = database[Config.TEMPLATES_COLLECTION].find_one(filter={"_id": "mongodb-datasource-template"})
     try:
-        validate(instance=document, schema=schema)
+        validate(instance=document, schema=schema["schema"])
     except ValidationError as error:
-        return abort(400, error)
+        return abort(400, message=error)

--- a/api/schemas/data-sources/azure-mongo-blueprints.json
+++ b/api/schemas/data-sources/azure-mongo-blueprints.json
@@ -1,5 +1,5 @@
 {
-  "type": "mongodb",
+  "type": "mongo-db",
   "host": "msa-dev.documents.azure.com",
   "port": 10255,
   "username": "msa-dev",

--- a/api/schemas/data-sources/azure-mongo-entities.json
+++ b/api/schemas/data-sources/azure-mongo-entities.json
@@ -1,5 +1,5 @@
 {
-  "type": "mongodb",
+  "type": "mongo-db",
   "host": "msa-dev.documents.azure.com",
   "port": 10255,
   "username": "msa-dev",

--- a/api/schemas/data-sources/local-mongo-blueprints.json
+++ b/api/schemas/data-sources/local-mongo-blueprints.json
@@ -1,5 +1,5 @@
 {
-  "type": "mongodb",
+  "type": "mongo-db",
   "host": "db",
   "port": 27017,
   "username": "maf",

--- a/api/schemas/data-sources/local-mongo-entities.json
+++ b/api/schemas/data-sources/local-mongo-entities.json
@@ -1,5 +1,5 @@
 {
-  "type": "mongodb",
+  "type": "mongo-db",
   "host": "db",
   "port": 27017,
   "username": "maf",

--- a/api/schemas/templates/mongodb.json
+++ b/api/schemas/templates/mongodb.json
@@ -6,15 +6,15 @@
   "schema": {
     "type": "object",
     "properties": {
-      "type": {
-        "type": "string",
-        "title": "Type",
-        "default": "mongodb"
-      },
       "documentType": {
         "type": "string",
-        "title": "Type",
-        "default": "mongodb"
+        "title": "documentType",
+        "default": ""
+      },
+      "name": {
+        "type": "string",
+        "title": "Name",
+        "minLength": 3
       },
       "host": {
         "type": "string",
@@ -38,11 +38,6 @@
         "title": "TLS",
         "default": false
       },
-      "name": {
-        "type": "string",
-        "title": "Name",
-        "minLength": 3
-      },
       "database": {
         "type": "string",
         "title": "Database"
@@ -52,12 +47,18 @@
         "title": "Collection"
       }
     },
-    "required": ["name"]
+    "required": ["name", "database", "collection", "host", "documentType", "port", "tls"]
   },
   "uiSchema": {
     "password": {
       "ui:widget": "password",
       "ui:help": "Hint: Make it strong!"
+    },
+    "name": {
+      "ui:help": "Must be globaly unique. May only contain [a-z,A-Z,0-9,-,_]'"
+    },
+    "documentType": {
+      "ui:widget": "hidden"
     }
   }
 }

--- a/api/tests_bdd/data_source.feature
+++ b/api/tests_bdd/data_source.feature
@@ -3,11 +3,11 @@ Feature: Data Source
   Background: There are data sources in the system
 
     Given there are mongodb data sources
-      | host     | port | username | password | tls  | name           | database   | collection | documentType |
-      | hostname | 1234 | user     | secret   | true | equinor-models | database_1 | blueprints | blueprints   |
+      | host     | port | username | password | tls  | name           | database   | collection | documentType | type    |
+      | hostname | 1234 | user     | secret   | true | equinor-models | database_1 | blueprints | blueprints   | mongo-db|
 
   Scenario: Get data source blueprints
-    Given I access the resource url "/api/data-sources/blueprints"
+    Given I access the resource url "/api/data-sources?documentType=blueprints"
     When I make a "GET" request
     Then the response status should be "OK"
     And the response should contain
@@ -25,13 +25,21 @@ Feature: Data Source
     """
 
   Scenario Outline: Create new data source
-    Given i access the resource url "/api/data-sources/equinor-models"
+    Given i access the resource url "/api/data-sources/myTest-DataSource"
     When i make a "POST" request
-    """
-    {
-      "host": "<host>",
-      "name": "<name>"
-    }
+      """
+       {
+      "type": "mongodb",
+      "host": "database-server.equinor.com",
+      "port": 27017,
+      "username": "test",
+      "password": "testpassword",
+      "tls": false,
+      "name": "myTest-DataSource",
+      "database": "mariner",
+      "collection": "blueprints",
+      "documentType": "blueprints"
+      }
     """
     Then the response status should be "<status>"
     #And the response should be
@@ -39,20 +47,28 @@ Feature: Data Source
     #"<name>"
     #"""
     Examples:
-      | host     | name     | status     |
-      | new host | new name | OK         |
-      | new host |          | OK         |
+      | host     | name     | status |
+      | new host | new name | OK     |
+      | new host |          | OK     |
 
 
   Scenario: Update data source
     Given i access the resource url "/api/data-sources/equinor-models"
     When i make a "PUT" request
-    """
-    {
-      "host": "updated host",
-      "name": "updated name"
-    }
-    """
+      """
+        {
+          "type": "mongodb",
+          "host": "database-server.equinor.com",
+          "port": 27017,
+          "username": "test",
+          "password": "testpassword",
+          "tls": false,
+          "name": "myTest-DataSource",
+          "database": "mariner",
+          "collection": "blueprints",
+          "documentType": "blueprints"
+        }
+      """
     Then the response should be
     """
     True
@@ -61,7 +77,7 @@ Feature: Data Source
   Scenario: Delete data source
     Given i access the resource url "/api/data-sources/equinor-models"
     When i make a "DELETE" request
-    Given I access the resource url "/api/data-sources/blueprints"
+    Given I access the resource url "/api/data-sources?documentType=blueprints"
     When I make a "GET" request
     Then the response should contain
     """

--- a/api/tests_bdd/document.feature
+++ b/api/tests_bdd/document.feature
@@ -3,8 +3,8 @@ Feature: Document
   Background: There are data sources in the system
 
     Given there are mongodb data sources
-      | host | port  | username | password | tls   | name                     | database | collection | documentType |
-      | db   | 27017 | maf      | maf      | false | local-blueprints-equinor | maf      | documents  | blueprints   |
+      | host | port  | username | password | tls   | name                     | database | collection | documentType | type    |
+      | db   | 27017 | maf      | maf      | false | local-blueprints-equinor | maf      | documents  | blueprints   | mongo-db|
 
     Given there are package named "package_1" of "documents"
       | title     | description         | version |

--- a/api/tests_bdd/index.feature
+++ b/api/tests_bdd/index.feature
@@ -3,8 +3,8 @@ Feature: Index
   Background: There are data sources in the system
 
     Given there are mongodb data sources
-      | host | port  | username | password | tls   | name                     | database | collection | documentType |
-      | db   | 27017 | maf      | maf      | false | local-blueprints-equinor | maf      | documents  | blueprints   |
+      | host | port  | username | password | tls   | name                     | database | collection | documentType | type   |
+      | db   | 27017 | maf      | maf      | false | local-blueprints-equinor | maf      | documents  | blueprints   |mongo-db|
 
     Given there are package named "package_1" of "documents"
       | title     | description         | version |

--- a/api/tests_bdd/steps/data_source.py
+++ b/api/tests_bdd/steps/data_source.py
@@ -17,6 +17,6 @@ def step_impl(context):
             "database": row["database"],
             "collection": row["collection"],
             "documentType": row["documentType"],
-            "type": "mongodb",
+            "type": row["type"],
         }
         data_modelling_tool_db["data_sources"].insert_one(document)

--- a/web/src/api/Api.ts
+++ b/web/src/api/Api.ts
@@ -114,15 +114,19 @@ export class IndexApi extends BaseApi {
 
 export class DmtApi {
   dataSourcesGet(dataSourceType: DataSourceType): string {
-    return `/api/data-sources/${dataSourceType}`
+    return `/api/data-sources?documentType=${dataSourceType}`
   }
 
   dataSourcesPut(datasourceId: string) {
     return `/api/data-sources/${datasourceId}`
   }
 
-  dataSourcesPost() {
-    return `/api/data-sources`
+  dataSourcesPost(datasourceId: string) {
+    return `/api/data-sources/${datasourceId}`
+  }
+
+  dataSourcesDelete(datasourceId: string) {
+    return `/api/data-sources/${datasourceId}`
   }
 
   indexGet(datasourceId: string) {

--- a/web/src/pages/blueprints/BlueprintsPage.tsx
+++ b/web/src/pages/blueprints/BlueprintsPage.tsx
@@ -13,6 +13,7 @@ import { RootFolderNode } from './nodes/RootFolderNode'
 import Header from '../../components/Header'
 import AddDatasource from '../common/tree-view/AddDatasource'
 import { DataSourceNode } from './nodes/DataSourceNode'
+import { DocumentType } from '../../util/variables'
 
 const api = new DmtApi()
 
@@ -58,7 +59,7 @@ export default () => {
     <Wrapper>
       <Header>
         <div />
-        <AddDatasource />
+        <AddDatasource documentType={DocumentType.BLUEPRINTS} />
       </Header>
       <br />
       <DocumentTree

--- a/web/src/pages/common/tree-view/AddDatasource.tsx
+++ b/web/src/pages/common/tree-view/AddDatasource.tsx
@@ -11,9 +11,15 @@ import Button from '../../../components/Button'
 import Api2 from '../../../api/Api2'
 const api = new DmtApi()
 
-export default () => {
+type Props = {
+  documentType: string
+}
+
+export default ({ documentType }: Props) => {
   const [showModal, setShowModal] = useState(false)
-  const [selectedDatasourceType, setSelectedDatasourceType] = useState('')
+  const [selectedDatasourceType, setSelectedDatasourceType] = useState(
+    'mongo-db'
+  )
 
   return (
     <div>
@@ -35,10 +41,13 @@ export default () => {
               selectedDatasourceType
             )}
             onSubmit={data => {
+              data.documentType = documentType
+              data.type = selectedDatasourceType
               axios
-                .post(api.dataSourcesPost(), data)
+                .post(api.dataSourcesPost(data.name), data)
                 .then((res: any) => {
                   NotificationManager.success('created datasource' + data.name)
+                  setShowModal(false)
                   //@todo fix when endpoint is ready.
                   // dispatch(EntitiesActions.addDatasource(res.data))
                 })

--- a/web/src/util/variables.tsx
+++ b/web/src/util/variables.tsx
@@ -1,0 +1,4 @@
+export enum DocumentType {
+  ENTITIES = 'entities',
+  BLUEPRINTS = 'blueprints',
+}


### PR DESCRIPTION
## What does this pull request change?
*Same endpoint for Create, Update, and Delete data-Source
*Hide documentType from schema
* Set documentType as prop on AddDatasource component


## Why is this pull request needed?
Resource crashed with others. More consistency
## Issues releated to this change:
