### PR TITLE
fix: filter path for blueprintPicker

### DIFF
--- a/api/core/use_case/add_entity_file_to_package_use_case.py
+++ b/api/core/use_case/add_entity_file_to_package_use_case.py
@@ -54,7 +54,7 @@ class AddEntityFileToPackageUseCase(uc.UseCase):
         uid = str(uuid4())
         file = Entity({"_id": uid, "uid": uid, "name": name, "type": type})
 
-        parent.documents += [{"_id": file._id, "name": file.name, "type": "ref"}]
+        parent.documents += [{"_id": file._id, "name": file.name, "type": file.type}]
         self.package_repository.update(parent)
 
         self.document_repository.add(DTO(data=file.to_dict(), uid=file._id, type=file.type))

--- a/web/src/components/widgets/DocumentFinderWidget.tsx
+++ b/web/src/components/widgets/DocumentFinderWidget.tsx
@@ -10,6 +10,18 @@ type Props = {
   formData: any
 }
 
+// Removes every other element in the path following datasource.
+function stripPackageAttributesFromPath(path: string) {
+  let elements = path.split('/')
+  const dataSource = elements[0]
+  elements.splice(0, 1)
+  const odd_elements = elements.filter(function(value, index) {
+    index -= 1
+    return index % 2 !== 0
+  })
+  return `${dataSource}/${odd_elements.join('/')}`
+}
+
 export default (props: any) => {
   const { value, onChange, attributeInput } = props
   const [blueprint, setBlueprint] = useState(value)
@@ -19,12 +31,16 @@ export default (props: any) => {
     const node = renderProps.treeNodeData
     // TODO: This is now true for all nodes?
     if (node.nodeType === NodeType.DOCUMENT_NODE) {
-      setBlueprint(`${renderProps.path}/${node.title}`)
+      const selectedNodePath = stripPackageAttributesFromPath(
+        `${renderProps.path}/${node.title}`
+      )
+      setBlueprint(selectedNodePath)
       setShowModal(false)
+
       if (attributeInput) {
-        onChange({ target: { value: `${renderProps.path}/${node.title}` } })
+        onChange({ target: { value: selectedNodePath } })
       } else {
-        onChange(`${renderProps.path}/${node.title}`)
+        onChange(selectedNodePath)
       }
     }
   }


### PR DESCRIPTION
## What does this pull request change?
* Filter the value from BlueprintPicker to not contain ie. "packages" or "documents"

## Why is this pull request needed?
* To be able to find referenced documents
* We dont want "documents" in a type-ref

## Issues releated to this change:
#226 
