### PR TITLE
fix: import ApplicationSetting

### DIFF
--- a/api/core/domain/package.py
+++ b/api/core/domain/package.py
@@ -34,6 +34,7 @@ class Package:
         type: str = DMT.PACKAGE.value,
         # TODO: Should handle refs and contained blueprints to be consistent with rest of the system
         documents: List[Dict] = None,
+        applications: List[Dict] = None,
         is_root: bool = False,
     ):
         self.name = name
@@ -42,6 +43,7 @@ class Package:
         self.type = type
         self.dependencies = [] if not dependencies else dependencies
         self.documents = [] if not documents else documents
+        self.applications = [] if not applications else applications
         self.packages = []
         self.applications = []
         self.is_root = is_root
@@ -54,6 +56,7 @@ class Package:
             uid=adict["_id"],
             description=adict.get("description"),
             documents=adict.get("documents", adict.get("blueprints")),
+            applications=adict.get("applications", ""),
             dependencies=[Dependency.from_dict(dependency) for dependency in adict.get("dependencies", [])],
             type=adict.get("type", DMT.PACKAGE.value),
             is_root=adict.get("isRoot", "false"),

--- a/api/utils/package_import.py
+++ b/api/utils/package_import.py
@@ -1,6 +1,6 @@
 import json
 import os
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Tuple
 from uuid import uuid4
 
 from config import Config
@@ -12,20 +12,28 @@ from services.database import data_modelling_tool_db as dmt_db
 from utils.logging import logger
 
 
-def _add_documents(path, documents, collection) -> List[Dict]:
+def _add_documents(path, documents, collection) -> Tuple[List[Dict], List[Dict]]:
     docs = []
+    app_settings = []
     for file in documents:
         with open(f"{path}/{file}") as json_file:
             data = json.load(json_file)
         data["uid"] = str(uuid4())
+
         if data["type"] == SIMOS.BLUEPRINT.value:
             document = Blueprint.from_dict(data)
         else:
             # TODO: Good candidate to become a DTO
             document = Entity(data)
+
         dmt_db[collection].replace_one({"_id": document.uid}, document.to_dict(), upsert=True)
-        docs.append({"_id": document.uid, "name": document.name})
-    return docs
+
+        if data["type"] == SIMOS.APPLICATION.value:
+            app_settings.append({"_id": document.uid, "name": document.name})
+        else:
+            docs.append({"_id": document.uid, "name": document.name})
+
+    return docs, app_settings
 
 
 def import_package(
@@ -39,8 +47,9 @@ def import_package(
         is_root=is_root,
     )
 
-    package.documents = _add_documents(path, documents=next(os.walk(path))[2], collection=collection)
-
+    package.documents, package.applications = _add_documents(
+        path, documents=next(os.walk(path))[2], collection=collection
+    )
     for folder in next(os.walk(path))[1]:
         package.packages.append(
             import_package(

--- a/home/core/SIMOS/Application.json
+++ b/home/core/SIMOS/Application.json
@@ -36,7 +36,7 @@
       "description": "Runnable recipes"
     },
     {
-      "type": "templates/SIMOS/ApplicationSetting",
+      "type": "system/SIMOS/ApplicationSetting",
       "name": "settings",
       "dimensions": "*",
       "description": "Application settings"

--- a/home/core/SIMOS/ApplicationSetting.json
+++ b/home/core/SIMOS/ApplicationSetting.json
@@ -1,5 +1,5 @@
 {
-  "type": "templates/SIMOS/Blueprint",
+  "type": "system/SIMOS/Blueprint",
   "name": "ApplicationSetting",
   "description": "This describes an application setting",
   "attributes": [


### PR DESCRIPTION
## What does this pull request change?
* Treats ApplicationSetting entities specially on import
## Why is this pull request needed?
* ApplicationSettings where being imported as any other blueprint/document

## Issues releated to this change:
#237 