### PR TITLE
Hide full schema on "create blueprint"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,4 +2,4 @@
 
 ## Why is this pull request needed?
 
-## Issues releated to this change:
+## Issues related to this change:

--- a/api/core/domain/ui_recipe.py
+++ b/api/core/domain/ui_recipe.py
@@ -31,12 +31,12 @@ class UIRecipe:
         attribute_contained = attribute.get("contained")
         is_array = attribute.get("dimensions", "") == "*"
 
-        if attribute_contained:
-            return attribute_contained
         if attribute_name in self.ui_attributes:
             ui_attribute = self.ui_attributes[attribute_name]
             if ui_attribute.is_contained is not None:
                 return ui_attribute.is_contained
+        if attribute_contained:
+            return attribute_contained
         if attribute_type in PRIMITIVES:
             return DEFAULT_PRIMITIVE_CONTAINED
         else:

--- a/api/reset-database.sh
+++ b/api/reset-database.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env sh
 set -eu
 
-mkdir -p /code/schemas/documents/entities
-
 flask nuke-db
 
 echo "ENVIRONMENT: $ENVIRONMENT"

--- a/home/core/SIMOS/Blueprint.json
+++ b/home/core/SIMOS/Blueprint.json
@@ -91,6 +91,25 @@
       ]
     },
     {
+      "type": "system/SIMOS/UIRecipe",
+      "name": "DEFAULT_CREATE",
+      "description": "",
+      "attributes": [
+        {
+          "name": "attributes",
+          "contained": false
+        },
+        {
+          "name": "storageRecipes",
+          "contained": false
+        },
+        {
+          "name": "uiRecipes",
+          "contained": false
+        }
+      ]
+    },
+    {
       "type": "system/SIMOS/UiRecipe",
       "name": "VIEW",
       "description": "",


### PR DESCRIPTION
## What does this pull request change?
* Don't override ui_recipe based on data-modell-contained
* Add "default_create" ui_recipe for blueprints

## Why is this pull request needed?
Don't want to show all attributes on a blueprint when you create it (only name and description)

## Issues related to this change:
#259 