### PR TITLE
hide blueprint tab based on application settings

### DIFF
--- a/api/config.py
+++ b/api/config.py
@@ -18,4 +18,5 @@ class Config:
     SYSTEM_COLLECTION = "system"
     CACHE_MAX_SIZE = 0 if ENVIRONMENT == "local" else 0
     APPLICATION_HOME = "/home"
+    SETTINGS_FILE = f"{APPLICATION_HOME}/settings.json"
     SYSTEM_FOLDERS = ["SIMOS", "DMT"]

--- a/api/core/rest/System.py
+++ b/api/core/rest/System.py
@@ -1,11 +1,15 @@
-from flask import Blueprint, send_file, Response
-from classes.data_source import DataSource
-from core.use_case.create_application_use_case import CreateApplicationUseCase, CreateApplicationRequestObject
-from utils.logging import logger
-from core.shared import response_object as res
-from core.repository.repository_factory import get_repository
-from core.enums import RepositoryType
 import json
+
+from flask import Blueprint, Response, send_file
+
+from classes.data_source import DataSource
+from core.enums import RepositoryType
+from core.repository.repository_factory import get_repository
+from core.shared import request_object as req
+from core.shared import response_object as res
+from core.use_case.create_application_use_case import CreateApplicationRequestObject, CreateApplicationUseCase
+from core.use_case.get_application_settings_use_case import GetApplicationSettingsUseCase
+from utils.logging import logger
 
 blueprint = Blueprint("system", __name__)
 
@@ -32,3 +36,19 @@ def post(data_source_id: str, application_id: str):
         )
     else:
         return Response(json.dumps(response.value), mimetype="application/json", status=STATUS_CODES[response.type])
+
+
+@blueprint.route("/api/v2/system/settings", methods=["GET"])
+def get():
+    use_case = GetApplicationSettingsUseCase()
+    response = use_case.execute(req)
+    if response.type == res.ResponseSuccess.SUCCESS:
+        return Response(
+            json.dumps(response.value), mimetype="application/json", status=STATUS_CODES[res.ResponseSuccess.SUCCESS]
+        )
+    else:
+        return Response(
+            json.dumps("Error: Failed to load the settings file."),
+            mimetype="application/json",
+            status=STATUS_CODES[res.ResponseFailure.SYSTEM_ERROR],
+        )

--- a/api/core/use_case/get_application_settings_use_case.py
+++ b/api/core/use_case/get_application_settings_use_case.py
@@ -1,0 +1,13 @@
+import json
+
+from config import Config
+from core.shared import response_object as res
+from core.shared import use_case as uc
+
+
+class GetApplicationSettingsUseCase(uc.UseCase):
+    def process_request(self, req):
+        with open(Config.SETTINGS_FILE) as settings_file:
+            settings = json.load(settings_file)
+
+        return res.ResponseSuccess(settings)

--- a/api/utils/package_import.py
+++ b/api/utils/package_import.py
@@ -14,6 +14,7 @@ from utils.logging import logger
 def _add_documents(path, documents, collection) -> List[Dict]:
     docs = []
     for file in documents:
+        logger.info(f"Working on {file}...")
         with open(f"{path}/{file}") as json_file:
             data = json.load(json_file)
         if data["type"] == SIMOS.BLUEPRINT.value:

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -1,9 +1,7 @@
 import React from 'react'
 import { createGlobalStyle } from 'styled-components'
 import { BrowserRouter as Router, Route } from 'react-router-dom'
-import BlueprintsPage from './pages/blueprints/BlueprintsPage'
 import { NotificationContainer } from 'react-notifications'
-import EntitiesPage from './pages/entities/EntitiesPage'
 import DocumentEditorPage from './pages/DocumentEditorPage'
 import { Switch } from 'react-router'
 
@@ -11,16 +9,11 @@ const GlobalStyle = createGlobalStyle`
   body {
     padding: 0;
     margin: 0;
-    // margin: 0 auto 25px;
-    // max-width: 1600px;
     font-family: Equinor-Regular, sans-serif;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
   
-  #root {
-    // max-width: 1600px;
-  }
 `
 
 function App() {
@@ -31,8 +24,6 @@ function App() {
       <NotificationContainer />
 
       <Switch>
-        <Route path="/blueprints" component={BlueprintsPage} />
-        <Route path="/entities" component={EntitiesPage} />
         <Route exact path="/" component={DocumentEditorPage} />
       </Switch>
     </Router>

--- a/web/src/api/Api.ts
+++ b/web/src/api/Api.ts
@@ -97,6 +97,9 @@ export class DmtApi {
   dataSourcesGet(dataSourceType: DataSourceType): string {
     return `/api/v2/data-sources?documentType=${dataSourceType}`
   }
+  applicationSettingsGet(): string {
+    return `/api/v2/system/settings`
+  }
 
   dataSourcesPost(datasourceId: string) {
     return `/api/v2/data-sources/${datasourceId}`

--- a/web/src/api/Api2.ts
+++ b/web/src/api/Api2.ts
@@ -88,6 +88,17 @@ export default class Api2 {
     }
   }
 
+  static fetchApplicationSettings() {
+    return ({ onSuccess, onError }: BASE_CRUD): void => {
+      axios
+        .get(api.applicationSettingsGet())
+        .then(({ data }) => {
+          onSuccess(data)
+        })
+        .catch(onError)
+    }
+  }
+
   static fetchWithTemplate({
     urlSchema,
     urlData,

--- a/web/src/pages/DocumentEditorPage.tsx
+++ b/web/src/pages/DocumentEditorPage.tsx
@@ -1,16 +1,18 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Col, Grid, Row } from 'react-styled-flexboxgrid'
 import styled from 'styled-components'
 import { GoldenLayoutComponent } from './common/golden-layout/GoldenLayoutComponent'
 import GoldenLayoutPanel from './common/golden-layout/GoldenLayoutPanel'
 import DocumentComponent from './common/layout-components/DocumentComponent'
 import BlueprintsPage from './blueprints/BlueprintsPage'
-import Tabs, { Tab, TabPanel, TabList } from '../components/Tabs'
+import Tabs, { Tab, TabList, TabPanel } from '../components/Tabs'
 import {
   LayoutComponents,
   LayoutProvider,
 } from './common/golden-layout/LayoutContext'
+import { DocumentType } from '../util/variables'
 import EntitiesPage from './entities/EntitiesPage'
+import Api2 from '../api/Api2'
 
 function wrapComponent(Component: any, state: any) {
   class Wrapped extends React.Component {
@@ -34,6 +36,29 @@ export default () => {
   const state = null
 
   const [layout, setLayout] = useState({ myLayout: null })
+  const [tabs, setTabs] = useState(new Set([DocumentType.ENTITIES]))
+  const [loading, setLoading] = useState<boolean | null>(null)
+
+  useEffect(() => {
+    {
+      Api2.fetchApplicationSettings()({
+        onSuccess: (settings: any) => {
+          if (
+            settings.blueprintsModels !== undefined &&
+            settings.blueprintsModels.length > 0
+          ) {
+            setTabs(prevState => prevState.add(DocumentType.BLUEPRINTS))
+            setLoading(false)
+          }
+        },
+        onError: (err: any) => setLoading(false),
+      })
+    }
+  }, [tabs])
+
+  if (loading) {
+    return <div>Loading...</div>
+  }
 
   return (
     <LayoutProvider layout={layout}>
@@ -43,18 +68,22 @@ export default () => {
             <Col xs={12} md={12} lg={3}>
               <Wrapper>
                 <h4>Data Modelling Tool</h4>
-                <Tabs>
-                  <TabList>
-                    <Tab>Blueprints</Tab>
-                    <Tab>Entities</Tab>
-                  </TabList>
-                  <TabPanel>
-                    <BlueprintsPage />
-                  </TabPanel>
-                  <TabPanel>
-                    <EntitiesPage />
-                  </TabPanel>
-                </Tabs>
+                {tabs.size > 1 ? (
+                  <Tabs>
+                    <TabList>
+                      <Tab>Blueprints</Tab>
+                      <Tab>Entities</Tab>
+                    </TabList>
+                    <TabPanel>
+                      <BlueprintsPage />
+                    </TabPanel>
+                    <TabPanel>
+                      <EntitiesPage />
+                    </TabPanel>
+                  </Tabs>
+                ) : (
+                  <EntitiesPage />
+                )}
               </Wrapper>
             </Col>
           )}


### PR DESCRIPTION
## What does this pull request change?
* New API endpoint to serve application settings from home
* Web consumes the application settings to decide to show blueprints tab or not.

This is a bit weird. We could have a "isTHEDMTApplication", as we'r not dynamically creating the front end. But this way of doing it matches more closely with a future ApplicationGenerator" 
## Why is this pull request needed?
* The user don't want to see the blueprints in his application
## Issues related to this change:
#285 