### PR TITLE
wip: fix defaults AttributeWidget

### DIFF
--- a/home/core/SIMOS/BlueprintAttribute.json
+++ b/home/core/SIMOS/BlueprintAttribute.json
@@ -6,12 +6,14 @@
     {
       "type": "string",
       "name": "name",
+      "default": "",
       "optional": false
     },
     {
       "type": "string",
       "name": "description",
-      "optional": true
+      "default": "",
+      "optional": false
     },
     {
       "name": "default",
@@ -24,6 +26,7 @@
       "type": "string",
       "name": "type",
       "enumType": "system/SIMOS/AttributeTypes",
+      "default": "string",
       "optional": false
     },
     {


### PR DESCRIPTION
## What does this pull request change?
add defaults. 

## Why is this pull request needed?
After creating a blueprint and submit, name, type and description may not have any values unless the user have explicit set any.

## Issues related to this change:
