### PR TITLE
set defaults in edit plugin

### DIFF
--- a/api/home/core/SIMOS/Blueprint.json
+++ b/api/home/core/SIMOS/Blueprint.json
@@ -68,31 +68,13 @@
       "plugin": "INDEX",
       "description": "",
       "attributes": [
-        {
-          "name": "name",
-          "disabled": true
-        },
-        {
-          "name": "type",
-          "disabled": true
-        },
-        {
-          "name": "description",
-          "widget": "textarea"
-        },
-        {
-          "name": "attributes",
-          "field": "attribute"
-        },
-        {
+                {
           "name": "storageRecipes",
-          "contained": true,
-          "field": "collapsible"
+          "contained": true
         },
         {
           "name": "uiRecipes",
-          "contained": true,
-          "field": "collapsible"
+          "contained": true
         }
       ]
     },
@@ -148,17 +130,6 @@
       "description": "",
       "plugin": "EDIT_PLUGIN",
       "attributes": [
-        {
-          "name": "name",
-          "field": "readonly"
-        },
-        {
-          "name": "description",
-          "widget": "textarea"
-        },
-        { "name":  "type",
-          "field": "readonly"
-        },
         {
           "name": "attributes",
           "field": "attribute"

--- a/web/src/plugins/BlueprintUtil.ts
+++ b/web/src/plugins/BlueprintUtil.ts
@@ -1,0 +1,39 @@
+import {Blueprint} from "./types";
+
+export type KeyValue = {
+	[key: string]: any
+}
+
+export class BlueprintUtil {
+	private attributes: KeyValue = {}
+	private uiRecipes: KeyValue = {}
+
+	constructor(blueprint: Blueprint, pluginName: string) {
+
+		this.addAttributes(this.attributes, blueprint.attributes)
+
+		blueprint.uiRecipes
+			.filter((recipe: any) => recipe.plugin === pluginName)
+			.forEach((recipe: any) => {
+			const pluginKey = recipe.plugin
+			if (pluginKey) {
+				this.uiRecipes[pluginKey] = {}
+				if (recipe.attributes) {
+					this.addAttributes(this.uiRecipes[pluginKey], recipe.attributes)
+				}
+			}
+		})
+	}
+
+	private addAttributes(container: KeyValue, attributes: any[]): void {
+		attributes.forEach((attr: any) => {
+			container[attr.name] = attr
+		})
+	}
+
+	public getUiAttribute(name: string, pluginName: string): object|undefined {
+		if (this.uiRecipes && this.uiRecipes[pluginName]) {
+			return this.uiRecipes[pluginName][name]
+		}
+	}
+}

--- a/web/src/plugins/__tests__/BlueprintUtilTest.ts
+++ b/web/src/plugins/__tests__/BlueprintUtilTest.ts
@@ -1,0 +1,35 @@
+import {BlueprintUtil} from "../BlueprintUtil";
+
+
+describe('BlueprintUtilTest',() => {
+	let blueprintUtil: any;
+
+
+	beforeEach(() => {
+		blueprintUtil = new BlueprintUtil({
+			name: '',
+			description: '',
+			type: '',
+			attributes: [
+				{name: 'test', type: 'string'}
+			],
+			uiRecipes: [
+				{
+					plugin: 'edit',
+					attributes: [
+						{
+							name: 'test',
+							widget: 'textarea'
+						}
+					]
+				}
+			],
+			storageRecipes: []
+		}, 'edit')
+	})
+
+	it('Should ', () => {
+		const uiAttribute = blueprintUtil.getUiAttribute('test', 'edit')
+		expect(uiAttribute).toEqual({name: 'test', widget: 'textarea'})
+	})
+})

--- a/web/src/plugins/form_rjsf_edit/CreateConfig.ts
+++ b/web/src/plugins/form_rjsf_edit/CreateConfig.ts
@@ -33,6 +33,6 @@ export function createFormConfigs(
   return {
     data: document,
     template: generateTemplate(attributes, blueprints),
-    uiSchema: generateUiSchema(pluginProps, uiRecipe),
+    uiSchema: generateUiSchema(pluginProps),
   }
 }

--- a/web/src/plugins/form_rjsf_edit/EditForm.tsx
+++ b/web/src/plugins/form_rjsf_edit/EditForm.tsx
@@ -4,7 +4,6 @@ import { Blueprint, PluginProps } from '../types'
 import { createFormConfigs, FormConfig } from './CreateConfig'
 import { findRecipe, setupTypeAndRecipe } from '../pluginUtils'
 import { AttributeWidget } from '../form-rjsf-widgets/Attribute'
-import { ReadOnly } from '../form-rjsf-widgets/ReadOnly'
 
 interface Props extends PluginProps {
   onSubmit: (data: any) => void
@@ -23,7 +22,6 @@ export const EditPlugin = (props: Props) => {
         fields={{
           attribute: AttributeWidget,
           hidden: () => <div />,
-          readonly: ReadOnly,
         }}
         onChange={formData => {
           console.log(formData)

--- a/web/src/plugins/pluginUtils.ts
+++ b/web/src/plugins/pluginUtils.ts
@@ -40,27 +40,6 @@ export function getBlueprintFromType(
   })
 }
 
-/**
- * Should be a blueprint for application wide defaults on the enum AttributeTypes.
- * To avoid specifying default in every blueprint that's created, define generic defaults.
- *
- * @param attribute
- */
-export function getDefaults(attribute: BlueprintAttribute) {
-  switch (attribute.type) {
-    case 'string':
-      return ''
-    case 'number':
-      return 0
-    case 'boolean':
-      return false
-    case 'integer':
-      return 0
-    default:
-      //type is a blueprint.
-      return attribute.dimensions === '*' ? [] : {}
-  }
-}
 
 /**
  * Parse attribute default values.


### PR DESCRIPTION
add blueprintUtil class to abstract internals of a blueprint
* disable name and type on entities (including the blueprint entity)
* description is always textarea on the entity

## What does this pull request change?
Edit plugin

## Why is this pull request needed?
Users should edit name and type of an entity, it's handled by add-file

## Issues related to this change:
