### PR TITLE
fix recipes

### DIFF
--- a/api/core/domain/recipe.py
+++ b/api/core/domain/recipe.py
@@ -1,0 +1,58 @@
+from typing import List
+
+PRIMITIVES = ["string", "number", "integer", "boolean"]
+
+INDEX_PRIMITIVE_CONTAINED = False
+INDEX_ARRAY_CONTAINED = True
+INDEX_TYPE_CONTAINED = False
+
+class RecipeAttribute:
+    def __init__(self, name: str, is_contained: bool = None):
+        self.name = name
+        self.is_contained = is_contained
+
+
+class Recipe:
+    def __init__(self, name: str, plugin_name: str, attributes: List = None):
+        self.name = name
+        self.plugin = plugin_name
+        self.recipe_attributes = {}
+        if attributes:
+            self._convert_attributes(attributes)
+
+    def _convert_attributes(self, attributes):
+        for attribute in attributes:
+            self.recipe_attributes[attribute["name"]] = RecipeAttribute(
+                name=attribute["name"], is_contained=attribute.get("contained")
+            )
+
+    def is_contained(self, attribute):
+        print(f"is_contained:" + self.plugin, self.name)
+        if self.plugin == 'INDEX':
+            return self.is_contained_in_index(attribute)
+
+
+    def is_contained_in_index(self, attribute):
+        attribute_name = attribute["name"]
+        attribute_type = attribute["type"]
+        is_array = attribute.get("dimensions", "") == "*"
+
+        if attribute_name in self.recipe_attributes:
+            ui_attribute = self.recipe_attributes[attribute_name]
+            if ui_attribute is not None and ui_attribute.is_contained is not None:
+                return ui_attribute.is_contained
+
+        if attribute_type in PRIMITIVES:
+            return INDEX_PRIMITIVE_CONTAINED
+        else:
+            if attribute_name == 'attributes':
+                return False
+            elif is_array:
+                return INDEX_ARRAY_CONTAINED
+            else:
+                return INDEX_TYPE_CONTAINED
+
+
+class DefaultRecipe(Recipe):
+    def __init__(self, plugin_name: str):
+        super().__init__("Default", plugin_name=plugin_name)

--- a/api/core/use_case/utils/get_ui_recipe.py
+++ b/api/core/use_case/utils/get_ui_recipe.py
@@ -1,3 +1,4 @@
+from core.domain.recipe import Recipe, DefaultRecipe
 from core.domain.ui_recipe import UIRecipe, DefaultUIRecipe
 
 
@@ -14,3 +15,12 @@ def get_ui_recipe(blueprint, ui_recipe_name) -> UIRecipe:
                     attributes.append({"name": attribute["name"], "contained": False})
                 return UIRecipe(name=ui_recipe_name, attributes=attributes)
     return DefaultUIRecipe()
+
+def get_recipe(blueprint, plugin_name) -> Recipe:
+    # todo check plugin_name against all plugins and check if type is ui or storage
+    if blueprint is not None:
+        if plugin_name is not None and blueprint.ui_recipes is not None:
+            recipe = next((x for x in blueprint.ui_recipes if "plugin" in x and  x["plugin"] == plugin_name), None)
+            if recipe:
+                return Recipe(name=recipe["name"], plugin_name=plugin_name, attributes=recipe.get("attributes", []))
+    return DefaultRecipe(plugin_name=plugin_name)

--- a/api/home/core/SIMOS/Blueprint.json
+++ b/api/home/core/SIMOS/Blueprint.json
@@ -68,14 +68,7 @@
       "plugin": "INDEX",
       "description": "",
       "attributes": [
-                {
-          "name": "storageRecipes",
-          "contained": true
-        },
-        {
-          "name": "uiRecipes",
-          "contained": true
-        }
+
       ]
     },
     {
@@ -133,14 +126,6 @@
         {
           "name": "attributes",
           "field": "attribute"
-        },
-        {
-          "name": "uiRecipes",
-          "contained": false
-        },
-        {
-          "name": "storageRecipes",
-          "contained": false
         }
       ]
     }

--- a/web/src/plugins/BlueprintUtil.ts
+++ b/web/src/plugins/BlueprintUtil.ts
@@ -1,39 +1,53 @@
-import {Blueprint} from "./types";
+import { Blueprint } from './types'
 
 export type KeyValue = {
-	[key: string]: any
+  [key: string]: any
 }
 
 export class BlueprintUtil {
-	private attributes: KeyValue = {}
-	private uiRecipes: KeyValue = {}
+  private attributes: KeyValue = {}
+  private uiRecipes: KeyValue = {}
 
-	constructor(blueprint: Blueprint, pluginName: string) {
+  constructor(blueprint: Blueprint, pluginName: string) {
+    this.addAttributes(this.attributes, blueprint.attributes)
 
-		this.addAttributes(this.attributes, blueprint.attributes)
+    blueprint.uiRecipes
+      .filter((recipe: any) => recipe.plugin === pluginName)
+      .forEach((recipe: any) => {
+        const pluginKey = recipe.plugin
+        if (pluginKey) {
+          this.uiRecipes[pluginKey] = {}
+          if (recipe.attributes) {
+            this.addAttributes(this.uiRecipes[pluginKey], recipe.attributes)
+          }
+        }
+      })
+  }
 
-		blueprint.uiRecipes
-			.filter((recipe: any) => recipe.plugin === pluginName)
-			.forEach((recipe: any) => {
-			const pluginKey = recipe.plugin
-			if (pluginKey) {
-				this.uiRecipes[pluginKey] = {}
-				if (recipe.attributes) {
-					this.addAttributes(this.uiRecipes[pluginKey], recipe.attributes)
-				}
-			}
-		})
-	}
+  private addAttributes(container: KeyValue, attributes: any[]): void {
+    attributes.forEach((attr: any) => {
+      container[attr.name] = attr
+    })
+  }
 
-	private addAttributes(container: KeyValue, attributes: any[]): void {
-		attributes.forEach((attr: any) => {
-			container[attr.name] = attr
-		})
-	}
+  public getUiAttribute(name: string, pluginName: string): object | undefined {
+    if (this.uiRecipes && this.uiRecipes[pluginName]) {
+      return this.uiRecipes[pluginName][name]
+    }
+  }
 
-	public getUiAttribute(name: string, pluginName: string): object|undefined {
-		if (this.uiRecipes && this.uiRecipes[pluginName]) {
-			return this.uiRecipes[pluginName][name]
-		}
-	}
+  public static getAttributeByName(
+    attributes: any,
+    name: string
+  ): KeyValue | undefined {
+    if (attributes) {
+      return attributes.find((attr: any) => attr.name === name)
+    }
+  }
+
+  public static findRecipe(recipes: any[], pluginName: string): any {
+    if (recipes) {
+      return recipes.find((recipe: any) => recipe.plugin === pluginName)
+    }
+  }
 }

--- a/web/src/plugins/UtilIndexPlugin.ts
+++ b/web/src/plugins/UtilIndexPlugin.ts
@@ -1,0 +1,45 @@
+import { BlueprintUtil } from './BlueprintUtil'
+import { isPrimitive } from './pluginUtils'
+
+const INDEX_PRIMITIVE_CONTAINED = false
+const INDEX_ARRAY_CONTAINED = true
+const INDEX_TYPE_CONTAINED = false
+
+export class UtilIndexPlugin {
+  /**
+   * Filter attributes contained in the index.
+   *
+   * @param blueprinAttribute
+   */
+  public static filterByIndexPlugin(indexPlugin: any, indexRecipe: any) {
+    indexRecipe = indexRecipe || {}
+    //@todo read defaults from indexPlugin.
+    return (attr: any) => {
+      const indexAttribute = BlueprintUtil.getAttributeByName(
+        indexRecipe.attributes,
+        attr.name
+      )
+
+      // override defaults
+      if (indexAttribute && indexAttribute.contained !== undefined) {
+        // filter opposite of indexAttribute
+        return indexAttribute.contained
+      }
+      // index plugin defaults
+      const isArray = attr.dimensions === '*'
+      const isType = !isPrimitive(attr.type)
+
+      if (!isType) {
+        return INDEX_PRIMITIVE_CONTAINED
+      } else {
+        if (attr.name === 'attributes') {
+          return true
+        } else if (isArray) {
+          return INDEX_ARRAY_CONTAINED
+        } else {
+          return INDEX_TYPE_CONTAINED
+        }
+      }
+    }
+  }
+}

--- a/web/src/plugins/__tests__/BlueprintUtilTest.ts
+++ b/web/src/plugins/__tests__/BlueprintUtilTest.ts
@@ -1,35 +1,34 @@
-import {BlueprintUtil} from "../BlueprintUtil";
+import { BlueprintUtil } from '../BlueprintUtil'
 
+describe('BlueprintUtilTest', () => {
+  let blueprintUtil: any
 
-describe('BlueprintUtilTest',() => {
-	let blueprintUtil: any;
+  beforeEach(() => {
+    blueprintUtil = new BlueprintUtil(
+      {
+        name: '',
+        description: '',
+        type: '',
+        attributes: [{ name: 'test', type: 'string' }],
+        uiRecipes: [
+          {
+            plugin: 'edit',
+            attributes: [
+              {
+                name: 'test',
+                widget: 'textarea',
+              },
+            ],
+          },
+        ],
+        storageRecipes: [],
+      },
+      'edit'
+    )
+  })
 
-
-	beforeEach(() => {
-		blueprintUtil = new BlueprintUtil({
-			name: '',
-			description: '',
-			type: '',
-			attributes: [
-				{name: 'test', type: 'string'}
-			],
-			uiRecipes: [
-				{
-					plugin: 'edit',
-					attributes: [
-						{
-							name: 'test',
-							widget: 'textarea'
-						}
-					]
-				}
-			],
-			storageRecipes: []
-		}, 'edit')
-	})
-
-	it('Should ', () => {
-		const uiAttribute = blueprintUtil.getUiAttribute('test', 'edit')
-		expect(uiAttribute).toEqual({name: 'test', widget: 'textarea'})
-	})
+  it('Should ', () => {
+    const uiAttribute = blueprintUtil.getUiAttribute('test', 'edit')
+    expect(uiAttribute).toEqual({ name: 'test', widget: 'textarea' })
+  })
 })

--- a/web/src/plugins/__tests__/UtilIndexPluginTest.ts
+++ b/web/src/plugins/__tests__/UtilIndexPluginTest.ts
@@ -1,0 +1,105 @@
+import { UtilIndexPlugin } from '../UtilIndexPlugin'
+
+function createIndexAttribute(name: string, contained: boolean) {
+  return { name, contained }
+}
+
+function createBlueprintAttribute(
+  name: string,
+  type: string,
+  isArray: boolean
+) {
+  return {
+    name,
+    type,
+    dimensions: isArray ? '*' : '',
+  }
+}
+
+describe('UtilIndexPluginTest', () => {
+  describe('Filter defaults contained in treeView', () => {
+    it('should not filter primitives', () => {
+      const filterIndex = UtilIndexPlugin.filterByIndexPlugin(null, null)
+      const attributes = [createBlueprintAttribute('item', 'string', false)]
+      expect(attributes.filter(filterIndex)).toMatchObject([])
+    })
+
+    it('should not filter type', () => {
+      const filterIndex = UtilIndexPlugin.filterByIndexPlugin(null, null)
+      const attributes = [
+        createBlueprintAttribute('item', 'system/Blueprint', false),
+      ]
+      expect(attributes.filter(filterIndex)).toMatchObject([])
+    })
+
+    it('should filter array', () => {
+      const filterIndex = UtilIndexPlugin.filterByIndexPlugin(null, null)
+      const attributes = [
+        createBlueprintAttribute('item', 'system/Blueprint', true),
+      ]
+      expect(attributes.filter(filterIndex)).toMatchObject(attributes)
+    })
+  })
+
+  describe('Filter array contained in treeView', () => {
+    it('should filter array type, contained in TreeView', () => {
+      const filterIndex = UtilIndexPlugin.filterByIndexPlugin(null, {
+        attributes: [createIndexAttribute('item', true)],
+      })
+      const attributes = [
+        createBlueprintAttribute('item', 'system/BlueprintAttribute', true),
+      ]
+      expect(attributes.filter(filterIndex)).toMatchObject(attributes)
+    })
+
+    it('should not filter array type, not contained in TreeView', () => {
+      const filterIndex = UtilIndexPlugin.filterByIndexPlugin(null, {
+        attributes: [createIndexAttribute('item', false)],
+      })
+      const attributes = [
+        createBlueprintAttribute('item', 'system/BlueprintAttribute', true),
+      ]
+      expect(attributes.filter(filterIndex)).toMatchObject([])
+    })
+  })
+
+  describe('Filter types in contained in Treeview', () => {
+    it('should filter type, contained in TreeView', () => {
+      const filterIndex = UtilIndexPlugin.filterByIndexPlugin(null, {
+        attributes: [createIndexAttribute('item', true)],
+      })
+      const attributes = [
+        createBlueprintAttribute('item', 'system/BlueprintAttribute', false),
+      ]
+      expect(attributes.filter(filterIndex)).toMatchObject(attributes)
+    })
+
+    it('should not filter array type, not contained in TreeView', () => {
+      const filterIndex = UtilIndexPlugin.filterByIndexPlugin(null, {
+        attributes: [createIndexAttribute('item', false)],
+      })
+      const attributes = [
+        createBlueprintAttribute('item', 'system/BlueprintAttribute', false),
+      ]
+      expect(attributes.filter(filterIndex)).toMatchObject([])
+    })
+  })
+
+  describe('Filter primitives contained in treeView', () => {
+    it('should filter primitive, contained in TreeView', () => {
+      const filterIndex = UtilIndexPlugin.filterByIndexPlugin(null, {
+        attributes: [createIndexAttribute('item', true)],
+      })
+      const attributes = [createBlueprintAttribute('item', 'string', false)]
+      expect(attributes.filter(filterIndex)).toMatchObject(attributes)
+    })
+
+    it('should not filter array primitive, not contained in TreeView', () => {
+      const filterIndex = UtilIndexPlugin.filterByIndexPlugin(null, {
+        attributes: [createIndexAttribute('item', false)],
+      })
+      const attributes = [createBlueprintAttribute('item', 'string', true)]
+      expect(attributes.filter(filterIndex)).toMatchObject([])
+    })
+  })
+})

--- a/web/src/plugins/form_rjsf_edit/EditForm.tsx
+++ b/web/src/plugins/form_rjsf_edit/EditForm.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import Form from 'react-jsonschema-form'
 import { Blueprint, PluginProps } from '../types'
 import { createFormConfigs, FormConfig } from './CreateConfig'
-import { findRecipe, setupTypeAndRecipe } from '../pluginUtils'
+import { setupTypeAndRecipe } from '../pluginUtils'
 import { AttributeWidget } from '../form-rjsf-widgets/Attribute'
 
 interface Props extends PluginProps {
@@ -10,8 +10,7 @@ interface Props extends PluginProps {
 }
 
 export const EditPlugin = (props: Props) => {
-  const uiRecipe = findRecipe(props.blueprint, props.name)
-  const config: FormConfig = createFormConfigs(props, uiRecipe)
+  const config: FormConfig = createFormConfigs(props)
   const formData = config.data
   return (
     <div style={{ marginBottom: 20 }}>

--- a/web/src/plugins/form_rjsf_edit/GenerateUiSchema.ts
+++ b/web/src/plugins/form_rjsf_edit/GenerateUiSchema.ts
@@ -1,6 +1,6 @@
 import { Blueprint, BlueprintAttribute, PluginProps } from '../types'
 import { getWidgetBlueprint } from './EditForm'
-import {BlueprintUtil, KeyValue} from "../BlueprintUtil";
+import { BlueprintUtil, KeyValue } from '../BlueprintUtil'
 
 type UiSchemaProperty = {
   items?: any
@@ -20,24 +20,22 @@ type UiSchemaProperty = {
 
 const PLUGIN_NAME = 'EDIT_PLUGIN'
 
-const defaults:KeyValue = {
-  name: {'ui:disabled': true},
-  type: {'ui:disabled': true},
-  description: {'ui:widget': 'textarea'},
-
+const defaults: KeyValue = {
+  name: { 'ui:disabled': true },
+  type: { 'ui:disabled': true },
+  description: { 'ui:widget': 'textarea' },
 }
 
 function addDefaultUiProperties(container: KeyValue, attr: any) {
-    const defaultUiProperty = defaults[attr.name]
-    if (defaultUiProperty) {
-      container[attr.name] = defaultUiProperty
-    }
+  const defaultUiProperty = defaults[attr.name]
+  if (defaultUiProperty) {
+    container[attr.name] = defaultUiProperty
+  }
 }
 
 export function generateUiSchema(pluginProps: PluginProps) {
-  const {blueprint} = pluginProps
+  const { blueprint } = pluginProps
   const blueprintUtil = new BlueprintUtil(pluginProps.blueprint, PLUGIN_NAME)
-
 
   const uiSchema = {}
   blueprint.attributes.forEach((attr: BlueprintAttribute) => {
@@ -47,11 +45,7 @@ export function generateUiSchema(pluginProps: PluginProps) {
     addDefaultUiProperties(uiSchema, attr)
 
     if (uiAttribute) {
-      let property = createUiSchemaProperty(
-        uiAttribute,
-        attr,
-        pluginProps
-      )
+      let property = createUiSchemaProperty(uiAttribute, attr, pluginProps)
 
       if (Object.keys(property).length > 0) {
         ;(uiSchema as any)[attr.name] = property
@@ -66,7 +60,6 @@ function createUiSchemaProperty(
   blueprintAttribute: BlueprintAttribute,
   pluginProps: PluginProps
 ) {
-
   if (uiAttribute.contained === false) {
     return { 'ui:field': 'hidden' }
   }

--- a/web/src/plugins/pluginUtils.ts
+++ b/web/src/plugins/pluginUtils.ts
@@ -40,7 +40,6 @@ export function getBlueprintFromType(
   })
 }
 
-
 /**
  * Parse attribute default values.
  * Since default is of type string, we can't store json type array, object, number or boolean.


### PR DESCRIPTION
## What does this pull request change?
Generate index use-case is changed from using ui_recipe to recipe. 
Recipe class should work for all kind of recipes.
Current code cant be reused, since ui_recipe is hiding details. 

New defaults in index plugin: 
* attributes contained
* types contained
* primitives not contained
* arrays not contained

Contained in index:
1. override with INDEX recipe (at attribute level)
2. use defaults

Contained in edit plugin:
1. override with EDIT_PLUGIN recipe (at attribute level)
2. use EDIT_PLUGIN defaults (attributes and primitives contained)
3.  use opposite defaults from index
   3.1  use index recipe if provided
   3.2 use defaults from index plugin

The idea is to move plugin defaults to plugin blueprints.

## Why is this pull request needed?
stabilize recipes. User can set contained on both index and edit plugin. 

## Issues related to this change:
#355 #311