### PR TITLE
focus last clicked tree node

### DIFF
--- a/web/src/pages/common/golden-layout/LayoutContext.tsx
+++ b/web/src/pages/common/golden-layout/LayoutContext.tsx
@@ -44,6 +44,13 @@ export const LayoutProvider = ({ children, layout }: Props) => {
     }
   }
 
+  const focus = (id: string) => {
+    if (isOpen(layout, id)) {
+      const window = layout.myLayout.root.getItemsById(id)[0]
+      window.parent.setActiveContentItem(window)
+    }
+  }
+
   const update = (id: string, title: string) => {
     if (isOpen(layout, id)) {
       const components = layout.myLayout.root.getItemsById(id)
@@ -65,6 +72,7 @@ export const LayoutProvider = ({ children, layout }: Props) => {
     <LayoutContext.Provider
       value={{
         add,
+        focus,
         remove,
         update,
         refresh,

--- a/web/src/pages/common/nodes/DocumentNode.tsx
+++ b/web/src/pages/common/nodes/DocumentNode.tsx
@@ -20,14 +20,15 @@ export const DocumentNode = (props: DocumentNodeProps) => {
           <WithContextMenu node={node} layout={layout}>
             {onSelect && (
               <div
-                onClick={() =>
+                onClick={() => {
                   layout.add(
                     onSelect.uid,
                     onSelect.title,
                     onSelect.component,
                     onSelect.data
                   )
-                }
+                  layout.focus(node.nodeData.nodeId)
+                }}
               >
                 {nodeData.title}
               </div>


### PR DESCRIPTION
## What does this pull request change?
* Adds an "FocusGoldenLayoutTab" action to onClick on DocumentNode used in the Tree

## Why is this pull request needed?
* UX

## Issues related to this change:
#366 