### PR TITLE
fix plugins ui

### DIFF
--- a/api/core/domain/recipe.py
+++ b/api/core/domain/recipe.py
@@ -29,7 +29,6 @@ class Recipe:
             self.recipe_attributes[name] = RecipeAttribute(name=name, is_contained=get(attribute, "contained"))
 
     def is_contained(self, attribute):
-        print(f"is_contained:" + self.plugin, self.name)
         if self.plugin == "INDEX":
             return self.is_contained_in_index(attribute)
 

--- a/api/core/rest/Index.py
+++ b/api/core/rest/Index.py
@@ -4,7 +4,6 @@ from flask import Blueprint, Response
 
 from classes.data_source import DataSource
 from core.repository.repository_factory import get_repository
-from core.enums import RepositoryType
 from core.use_case.generate_index_use_case import GenerateIndexUseCase
 
 blueprint = Blueprint("index", __name__)
@@ -42,14 +41,9 @@ def get_document(data_source_id: str, document_id: str):
 )
 def get_attribute(data_source_id: str, attribute: str, document_id: str):
     data_source = DataSource(id=data_source_id)
-    blueprint_repository = get_repository(RepositoryType.BlueprintRepository, data_source)
-    package_repository = get_repository(RepositoryType.PackageRepository, data_source)
-    document_repository = get_repository(RepositoryType.DocumentRepository, data_source)
+    document_repository = get_repository(data_source)
 
     use_case = GenerateIndexUseCase(
-        blueprint_repository=blueprint_repository,
-        package_repository=package_repository,
-        get_repository=get_repository,
         document_repository=document_repository,
     )
     result = use_case.single(

--- a/api/home/blueprints/CarsDemo/engine/FuelPump.json
+++ b/api/home/blueprints/CarsDemo/engine/FuelPump.json
@@ -6,6 +6,14 @@
     {
       "type": "string",
       "name": "name"
+    },
+    {
+      "type": "string",
+      "name": "description"
+    },
+    {
+      "type": "string",
+      "name": "type"
     }
   ]
 }

--- a/api/home/core/SIMOS/Blueprint.json
+++ b/api/home/core/SIMOS/Blueprint.json
@@ -45,7 +45,7 @@
       "attributes": [
         {
           "name": "attributes",
-          "type": "system/SIMOS/BlueprintAttribute",
+          "type": "system/SIMOS/StorageAttribute",
           "contained": true
         },
         {
@@ -62,21 +62,6 @@
     }
   ],
   "uiRecipes": [
-    {
-      "type": "system/SIMOS/UiRecipe",
-      "name": "PREVIEW",
-      "description": "",
-      "plugin": "PREVIEW",
-      "attributes": []
-    },
-    {
-      "type": "system/SIMOS/UiRecipe",
-      "name": "INDEX",
-      "plugin": "INDEX",
-      "description": "",
-      "attributes": [
-      ]
-    },
     {
       "type": "system/SIMOS/UIRecipe",
       "name": "DEFAULT_CREATE",
@@ -106,7 +91,7 @@
     },
     {
       "type": "system/SIMOS/UiRecipe",
-      "name": "VIEW",
+      "name": "View",
       "description": "",
       "plugin": "VIEW",
       "attributes": [
@@ -124,20 +109,20 @@
     },
     {
       "type": "system/SIMOS/UiRecipe",
-      "name": "TEST_EXTERNAL",
-      "description": "",
-      "plugin": "TEST_EXTERNAL",
+      "name": "My plugin",
+      "description": "Some external plugin",
+      "plugin": "EXTERNAL",
       "attributes": []
     },
     {
       "type": "system/SIMOS/UiRecipe",
-      "name": "Edit2",
+      "name": "Edit",
       "description": "",
       "plugin": "EDIT_PLUGIN",
       "attributes": [
         {
           "name": "attributes",
-          "type": "system/SIMOS/BlueprintAttribute",
+          "type": "system/SIMOS/UiAttribute",
           "field": "attribute"
         }
       ]

--- a/api/home/core/SIMOS/UiRecipe.json
+++ b/api/home/core/SIMOS/UiRecipe.json
@@ -43,5 +43,7 @@
       "optional": true,
       "contained": true
     }
-  ]
+  ],
+  "uiRecipes": [],
+  "storageRecipes": []
 }

--- a/api/home/entities/CarsDemo/Volvo.json
+++ b/api/home/entities/CarsDemo/Volvo.json
@@ -6,6 +6,11 @@
     "type": "SSR-DataSource/CarsDemo/engine/Engine",
     "description": "",
     "name": "V60",
-    "power": "100"
+    "power": "100",
+    "fuelPump": {
+      "type": "SSR-DataSource/CarsDemo/engine/FuelPump",
+      "description": "",
+      "name": "the fuel pump"
+    }
   }
 }

--- a/web/src/external-plugins/index.js
+++ b/web/src/external-plugins/index.js
@@ -12,10 +12,9 @@ const TestPlugin = ({ parent, document, children }) => {
 }
 
 const registeredPlugins = {
-  TEST_EXTERNAL: TestPlugin,
+  'My plugin': TestPlugin,
 }
 
-export default function pluginHook(plugin) {
-  console.log(plugin)
-  return registeredPlugins[plugin]
+export default function pluginHook(uiRecipe) {
+  return registeredPlugins[uiRecipe.name]
 }

--- a/web/src/pages/common/layout-components/DocumentComponent.tsx
+++ b/web/src/pages/common/layout-components/DocumentComponent.tsx
@@ -4,60 +4,24 @@ import ReactJsonSchemaWrapper, {
 } from '../form/ReactJsonSchemaWrapper'
 import styled from 'styled-components'
 import FetchDocument from '../utils/FetchDocument'
-// @ts-ignore
-import objectPath from 'object-path'
 import Tabs, { Tab, TabList, TabPanel } from '../../../components/Tabs'
 import BlueprintPreview from '../../../plugins/preview/PreviewPlugin'
 import pluginHook from '../../../external-plugins/index'
-import { EditPlugin, ViewPlugin, PlotPlugin } from '../../../plugins'
+import { EditPlugin, ViewPlugin } from '../../../plugins'
 import { LayoutContext } from '../golden-layout/LayoutContext'
-import { PluginProps } from '../../../plugins/types'
+import { PluginProps, UiRecipe } from '../../../plugins/types'
+import { GenerateUiRecipeTabs } from './GenerateUiRecipeTabs'
 
 const Wrapper = styled.div`
   padding: 20px;
 `
 
-//@todo add UiPlugin
 export enum RegisteredPlugins {
   PREVIEW = 'PREVIEW',
+  EDIT_PLUGIN = 'EDIT_PLUGIN',
   EDIT = 'EDIT',
   VIEW = 'VIEW',
-  EDIT_PLUGIN = 'EDIT_PLUGIN',
-  PLOT = 'PLOT',
-}
-
-const plugins: Plugin[] = [
-  {
-    label: 'Preview',
-    name: RegisteredPlugins.PREVIEW,
-  },
-  {
-    label: 'Edit',
-    name: RegisteredPlugins.EDIT,
-    disabled: true,
-  },
-  {
-    label: 'Edit',
-    name: RegisteredPlugins.EDIT_PLUGIN,
-  },
-  {
-    label: 'View',
-    name: RegisteredPlugins.VIEW,
-    disabled: true,
-  },
-  {
-    label: 'Plot',
-    name: RegisteredPlugins.PLOT,
-    disabled: true,
-  },
-]
-
-// based on plugin blueprints
-type Plugin = {
-  label: string
-  name: string
-  optional?: boolean
-  disabled?: boolean
+  EXTERNAL = 'EXTERNAL',
 }
 
 const View = (props: any) => {
@@ -68,17 +32,17 @@ const View = (props: any) => {
     document,
     dataUrl,
     attribute,
-    plugin,
+    uiRecipe,
   } = props
 
-  const pluginProps = {
+  const pluginProps: PluginProps = {
     blueprint,
     document,
     blueprints,
-    name: plugin.name,
+    uiRecipe,
   }
 
-  switch (plugin.name) {
+  switch (uiRecipe.plugin) {
     case RegisteredPlugins.PREVIEW:
       return <BlueprintPreview data={document} />
 
@@ -107,42 +71,40 @@ const View = (props: any) => {
           schemaUrl={schemaUrl}
           dataUrl={dataUrl}
           attribute={attribute}
-          uiRecipe={plugin.name}
+          uiRecipe={uiRecipe.name}
         />
       )
-
-    case RegisteredPlugins.PLOT:
-      return <PlotPlugin {...pluginProps} />
-
-    default:
-      const ExternalPlugin = pluginHook(plugin.name)
+    case RegisteredPlugins.EXTERNAL:
+      const ExternalPlugin = pluginHook(uiRecipe)
       if (ExternalPlugin) {
         return <ExternalPlugin {...props} />
       }
-      console.warn(`Plugin not supported: ${plugin.name}`)
-      return <div>{`Plugin not supported: ${plugin.name}`}</div>
+      break
   }
+  console.warn(`Plugin not supported: ${uiRecipe.plugin}`)
+  return <div>{`Plugin not supported: ${uiRecipe.plugin}`}</div>
 }
 
 const ViewList = (props: PluginProps) => {
-  const visiblePlugins = plugins.filter(
-    (plugin: Plugin) => plugin.disabled !== true
+  const generateUiRecipeTabs = new GenerateUiRecipeTabs(
+    props.blueprint.uiRecipes
   )
+  const uiRecipeTabs: UiRecipe[] = generateUiRecipeTabs.getTabs()
   return (
     <Tabs>
       <TabList>
-        {visiblePlugins.map((plugin: Plugin) => {
+        {uiRecipeTabs.map((uiRecipe: UiRecipe) => {
           return (
-            <Tab key={plugin.name} id={plugin.name}>
-              {plugin.label}
+            <Tab key={uiRecipe.name + uiRecipe.plugin} id={uiRecipe.plugin}>
+              {uiRecipe.name}
             </Tab>
           )
         })}
       </TabList>
-      {visiblePlugins.map((plugin: Plugin) => {
+      {uiRecipeTabs.map((uiRecipe: UiRecipe) => {
         return (
-          <TabPanel key={plugin.name}>
-            <View {...props} plugin={plugin} />
+          <TabPanel key={uiRecipe.name + uiRecipe.plugin}>
+            <View {...props} uiRecipe={uiRecipe} />
           </TabPanel>
         )
       })}

--- a/web/src/pages/common/layout-components/GenerateUiRecipeTabs.ts
+++ b/web/src/pages/common/layout-components/GenerateUiRecipeTabs.ts
@@ -1,0 +1,63 @@
+import { RegisteredPlugins } from './DocumentComponent'
+import {UiRecipe} from "../../../plugins/types";
+
+/**
+ * Requirements:
+ * 1. default tabs are listed first, in order.
+ * 2. custom tabs are listed in order.
+ * 3. default tabs can be replaced, without changing the order.
+ */
+export class GenerateUiRecipeTabs {
+  // turn enum into an object.
+  private registeredPluginsObject: Object = JSON.parse(
+    JSON.stringify(RegisteredPlugins)
+  )
+
+  private uiRecipeTabs: UiRecipe[] = []
+
+  constructor(uiRecipes: UiRecipe[], defaultTabs = getDefaultTabs()) {
+    this.uiRecipeTabs = defaultTabs
+
+    if (uiRecipes) {
+      uiRecipes.forEach((uiRecipe: UiRecipe) => {
+        const existingIndex = this.uiRecipeTabs.findIndex(
+          (tab: UiRecipe) => tab.name === uiRecipe.name
+        )
+        if (this.isUiPlugin(uiRecipe.plugin)) {
+          if (existingIndex > -1) {
+            this.replaceUiRecipe(existingIndex, uiRecipe)
+          } else {
+            this.addUiRecipe(uiRecipe)
+          }
+        }
+      })
+    }
+  }
+
+  private isUiPlugin(plugin: string) {
+    return (this.registeredPluginsObject as any)[plugin]
+  }
+
+  private replaceUiRecipe(atIndex: number, uiRecipe: UiRecipe) {
+    this.uiRecipeTabs.splice(atIndex, 1, uiRecipe)
+  }
+
+  private addUiRecipe(uiRecipe: UiRecipe) {
+    this.uiRecipeTabs.push(uiRecipe)
+  }
+
+  getTabs() {
+    return this.uiRecipeTabs
+  }
+}
+
+function createUiRecipe(name: string, plugin: string): UiRecipe {
+  return { name, plugin, attributes: [] }
+}
+
+export function getDefaultTabs(): UiRecipe[] {
+  return [
+    createUiRecipe('Raw', RegisteredPlugins.PREVIEW),
+    createUiRecipe('Edit', RegisteredPlugins.EDIT_PLUGIN),
+  ]
+}

--- a/web/src/pages/common/layout-components/__tests__/GenerateUiRecipeTest.ts
+++ b/web/src/pages/common/layout-components/__tests__/GenerateUiRecipeTest.ts
@@ -1,0 +1,47 @@
+import { GenerateUiRecipeTabs, getDefaultTabs } from '../GenerateUiRecipeTabs'
+
+describe('GenerateUiRecipeTabs', () => {
+  it('should add defaults', () => {
+    const tabsLength = getDefaultTabs().length
+    const generateUiTabs = new GenerateUiRecipeTabs([], getDefaultTabs())
+    const tabs = generateUiTabs.getTabs()
+    expect(tabs).toHaveLength(tabsLength)
+    expect(tabs).toMatchObject(getDefaultTabs())
+  })
+
+  it('should add a tab from a ui plugin', () => {
+    const generateUiTabs = new GenerateUiRecipeTabs(
+      [
+        {
+          name: 'my tab',
+          plugin: 'EDIT_PLUGIN',
+          attributes: [],
+        },
+      ],
+      getDefaultTabs()
+    )
+    const tabs = generateUiTabs.getTabs()
+    expect(tabs).toHaveLength(getDefaultTabs().length + 1)
+    expect(tabs).toMatchObject([
+      { name: 'Raw', plugin: 'PREVIEW', attributes: [] },
+      { name: 'Edit', plugin: 'EDIT_PLUGIN', attributes: [] },
+      { name: 'my tab', plugin: 'EDIT_PLUGIN', attributes: [] },
+    ])
+  })
+
+  it('should not add a tab from a ui plugin', () => {
+    const generateUiTabs = new GenerateUiRecipeTabs(
+      [
+        {
+          name: 'my tab',
+          plugin: 'INDEX',
+          attributes: [],
+        },
+      ],
+      getDefaultTabs()
+    )
+    const tabs = generateUiTabs.getTabs()
+    expect(tabs).toHaveLength(2)
+    expect(tabs).toMatchObject(getDefaultTabs())
+  })
+})

--- a/web/src/plugins/BlueprintUtil.ts
+++ b/web/src/plugins/BlueprintUtil.ts
@@ -45,9 +45,9 @@ export class BlueprintUtil {
     }
   }
 
-  public static findRecipe(recipes: any[], pluginName: string): any {
+  public static findRecipe(recipes: any[], name: string): any {
     if (recipes) {
-      return recipes.find((recipe: any) => recipe.plugin === pluginName)
+      return recipes.find((recipe: any) => recipe.name === name)
     }
   }
 }

--- a/web/src/plugins/form_rjsf_edit/CreateConfig.ts
+++ b/web/src/plugins/form_rjsf_edit/CreateConfig.ts
@@ -16,7 +16,7 @@ export function createFormConfigs(pluginProps: PluginProps): FormConfig {
   const indexRecipe = BlueprintUtil.findRecipe(blueprint.uiRecipes, 'INDEX')
   const editRecipe = BlueprintUtil.findRecipe(
     blueprint.uiRecipes,
-    'EDIT_PLUGIN'
+    pluginProps.uiRecipe.name
   )
 
   const filter = filterAttributes({ indexRecipe, editRecipe })

--- a/web/src/plugins/form_rjsf_edit/GenerateUiSchema.ts
+++ b/web/src/plugins/form_rjsf_edit/GenerateUiSchema.ts
@@ -18,8 +18,6 @@ type UiSchemaProperty = {
  * @param uiRecipe
  */
 
-const PLUGIN_NAME = 'EDIT_PLUGIN'
-
 const defaults: KeyValue = {
   name: { 'ui:disabled': true },
   type: { 'ui:disabled': true },
@@ -34,12 +32,15 @@ function addDefaultUiProperties(container: KeyValue, attr: any) {
 }
 
 export function generateUiSchema(pluginProps: PluginProps) {
-  const { blueprint } = pluginProps
-  const blueprintUtil = new BlueprintUtil(pluginProps.blueprint, PLUGIN_NAME)
+  const { blueprint, uiRecipe } = pluginProps
+  const blueprintUtil = new BlueprintUtil(
+    pluginProps.blueprint,
+    uiRecipe.plugin
+  )
 
   const uiSchema = {}
   blueprint.attributes.forEach((attr: BlueprintAttribute) => {
-    const uiAttribute = blueprintUtil.getUiAttribute(attr.name, PLUGIN_NAME)
+    const uiAttribute = blueprintUtil.getUiAttribute(attr.name, uiRecipe.plugin)
 
     // top level blueprint.
     addDefaultUiProperties(uiSchema, attr)
@@ -77,7 +78,7 @@ function createUiSchemaProperty(
           'ui:field': uiAttribute.field,
           attributes: widgetBlueprint.attributes,
           uiRecipe: widgetBlueprint.uiRecipes.find(
-            (recipe: any) => recipe.plugin === pluginProps.name
+            (recipe: any) => recipe.name === pluginProps.uiRecipe.name
           ),
         }
       }

--- a/web/src/plugins/plot/Plot.tsx
+++ b/web/src/plugins/plot/Plot.tsx
@@ -1,28 +1,20 @@
 import React from 'react'
-import { Blueprint } from '../types'
+import { Blueprint, PluginProps } from '../types'
 // @ts-ignore
 import { VictoryTheme, VictoryChart, VictoryLine } from 'victory'
 import { findRecipe } from '../pluginUtils'
 // @ts-ignore
 import objectPath from 'object-path'
+import { KeyValue } from '../BlueprintUtil'
 
-interface Props {
-  name: string
-  blueprint: Blueprint
-  document: Blueprint
-  blueprints: Blueprint[]
-}
-
-export const PlotPlugin = (props: Props) => {
-  const { blueprint, document } = props
-
-  const uiRecipe = findRecipe(blueprint, props.name)
-
-  const items = objectPath.get(document, uiRecipe.options.property)
+export const PlotPlugin = (props: PluginProps) => {
+  const { blueprint, document, uiRecipe } = props
+  const options: KeyValue = {}
+  const items = objectPath.get(document, options.property)
   const data = items.map((item: any) => {
     return {
-      x: item[uiRecipe.options.x],
-      y: item[uiRecipe.options.y],
+      x: item[options.x],
+      y: item[options.y],
     }
   })
 

--- a/web/src/plugins/pluginUtils.ts
+++ b/web/src/plugins/pluginUtils.ts
@@ -101,8 +101,7 @@ export function setupTypeAndRecipe(pluginProps?: PluginProps): TypeAndRecipe {
   if (!pluginProps) {
     return empty
   }
-  const { blueprint, blueprints, name } = pluginProps
-  const uiRecipe = pluginProps && findRecipe(blueprint, name)
+  const { blueprint, blueprints, uiRecipe } = pluginProps
   let uiAttributeType: any = {}
 
   if (!uiRecipe) {

--- a/web/src/plugins/types.ts
+++ b/web/src/plugins/types.ts
@@ -19,8 +19,15 @@ export type Blueprint = {
   storageRecipes: any[]
 }
 
-export type PluginProps = {
+// based on plugin blueprints
+export type UiRecipe = {
   name: string
+  plugin: string
+  attributes: BlueprintAttribute[] //@todo use UiAttribute
+}
+
+export type PluginProps = {
+  uiRecipe: UiRecipe //tab name, righthand side content
   blueprint: Blueprint
   document: Blueprint
   blueprints: Blueprint[]

--- a/web/src/plugins/view/ViewPlugin.tsx
+++ b/web/src/plugins/view/ViewPlugin.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
-import { BlueprintAttribute, PluginProps } from '../types'
+import { BlueprintAttribute, PluginProps, UiRecipe } from '../types'
 import ErrorBoundary from '../../components/ErrorBoundary'
 import TableWidget from '../widgets/table/TableWidget'
-import { RegisteredPlugins } from '../../pages/common/layout-components/DocumentComponent'
 import { Pre } from '../preview/PreviewPlugin'
 
 // available on attribute level of this.
@@ -11,10 +10,10 @@ enum ViewWidgets {
   TABLE_WIDGET = 'table.widget',
 }
 
-export const ViewPlugin = ({ blueprint, document }: PluginProps) => {
+export const ViewPlugin = ({ blueprint, document, uiRecipe }: PluginProps) => {
   const widgets = blueprint.attributes.map(
     (parentAttribute: BlueprintAttribute, index: number) => {
-      const plugin = getPluginOfAttribute(blueprint.uiRecipes, parentAttribute)
+      const plugin = uiRecipe.plugin
       const attribute = (document as any)[parentAttribute.name]
       const key = `${plugin}-${index}`
       switch (plugin) {
@@ -44,32 +43,6 @@ export const ViewPlugin = ({ blueprint, document }: PluginProps) => {
       <div style={{ padding: 20 }}>{widgets}</div>
     </div>
   )
-}
-
-/**
- * Each root level attribute in the blueprint, can have a plugin.
- * The plugin is a value on a attribute in the current uiRecipe.
- * @todo support default ui plugin when DocumentComponent is using the parents uiRecipe names only.
- *
- * @param uiRecipes from document
- * @param parentAttribute from blueprint
- */
-function getPluginOfAttribute(
-  uiRecipes: any[],
-  parentAttribute: BlueprintAttribute
-): string {
-  // The uiRecipe for this plugin must be provided.
-  const uiRecipe = uiRecipes.find(
-    (recipe: any) => recipe.plugin === RegisteredPlugins.VIEW
-  )
-  //find the ui attribute in parents uiRecipes.
-  const uiAttribute =
-    uiRecipe &&
-    uiRecipe.attributes &&
-    uiRecipe.attributes.find(
-      (uiAttr: any) => uiAttr.name === parentAttribute.name
-    )
-  return uiAttribute && uiAttribute.plugin
 }
 
 type DefaultViewProps = {

--- a/web/src/plugins/widgets/CollapsibleField.tsx
+++ b/web/src/plugins/widgets/CollapsibleField.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 // @ts-ignore
 import useCollapse from 'react-collapsed'
-import { FaChevronDown, FaChevronRight } from 'react-icons/all'
+import { FaChevronDown, FaChevronRight } from 'react-icons/fa'
 // @ts-ignore
 import objectPath from 'object-path'
 

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -8137,15 +8137,6 @@ methods@~1.1.2:
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
 
-metno-client@0.1.8:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/metno-client/-/metno-client-0.1.8.tgz#7f27a01650b818867af79a4fe5f69915cd7e9a9e"
-  integrity sha512-/x4NA1bcZZAi136pAyV996vvF2nkpldPKll767mn1BM4Ht2s6Wx3riyYYcC636CJCX1f3R+MQ2aS6s/XodLPWw==
-  dependencies:
-    debug "^2.2.0"
-    request "^2.72.0"
-    xml2js "^0.4.19"
-
 microevent.ts@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0"
@@ -11042,7 +11033,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.72.0, request@^2.87.0, request@^2.88.0:
+request@^2.87.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -11302,7 +11293,7 @@ sass-loader@7.2.0:
     pify "^4.0.1"
     semver "^5.5.0"
 
-sax@>=0.6.0, sax@^1.2.4, sax@~1.2.4:
+sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
@@ -13490,20 +13481,6 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
-
-xml2js@^0.4.19:
-  version "0.4.22"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.22.tgz#4fa2d846ec803237de86f30aa9b5f70b6600de02"
-  integrity sha512-MWTbxAQqclRSTnehWWe5nMKzI3VmJ8ltiJEco8akcC6j3miOhjjfzKum5sId+CWhfxdOs/1xauYr8/ZDBtQiRw==
-  dependencies:
-    sax ">=0.6.0"
-    util.promisify "~1.0.0"
-    xmlbuilder "~11.0.0"
-
-xmlbuilder@~11.0.0:
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
-  integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
 xmlchars@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
## What does this pull request change?
Tabs on right hand side in ui are generated based on default views and user defined uiRecipes. 
To add a tab view, use a supported ui plugin and name the recipe whatever. 

## Why is this pull request needed?
User should define as many views she want, even overriding the default ones. 
Only entity page can be customized, unless we expose the system blueprints to the user. Might be an option for admin/superuser when role is implemented. 
As discussed in meeting 15.november. 

## Issues related to this change:
#367 