### PR TITLE
fix document finder

### DIFF
--- a/web/src/plugins/form-rjsf-widgets/AttributeInputs.tsx
+++ b/web/src/plugins/form-rjsf-widgets/AttributeInputs.tsx
@@ -122,7 +122,9 @@ export const BlueprintInput = (props: BlueprintInputProps) => {
   return (
     <DocumentFinderWidget
       value={displayValue}
-      onChange={(event: any) => onChange(attribute, event.target.value)}
+      onChange={(value: any) => {
+        onChange(attribute, value)
+      }}
       attributeInput={true}
       packagesOnly={false}
       title={''}

--- a/web/src/plugins/form-rjsf-widgets/DocumentFinderWidget.tsx
+++ b/web/src/plugins/form-rjsf-widgets/DocumentFinderWidget.tsx
@@ -5,7 +5,7 @@ import { FilePicker } from '../../pages/common/FilePicker'
 import { NodeType } from '../../util/variables'
 
 export type Props = {
-  onChange: (event: any) => void
+  onChange: (value: any) => void
   value: string
   attributeInput: any
   packagesOnly: boolean
@@ -27,7 +27,7 @@ export default (props: Props) => {
       setShowModal(false)
 
       if (attributeInput) {
-        onChange({ target: { value: selectedNodePath } })
+        onChange(selectedNodePath)
       }
       if (packagesOnly) {
         onChange(node.nodeId)


### PR DESCRIPTION
## What does this pull request change?
fix document finder, works for add entity modal, but not blueprint attribute widget.

## Why is this pull request needed?

## Issues related to this change:
#407 