### PR TITLE
add validation on type #330

### DIFF
--- a/web/src/plugins/form_rjsf_edit/EditForm.tsx
+++ b/web/src/plugins/form_rjsf_edit/EditForm.tsx
@@ -84,7 +84,7 @@ function validate(blueprint: Blueprint) {
             if (!item.name) {
               errors[key][index].addError('name must be set')
             }
-            if (!item.type) {
+            if (!item.type || item.type === 'blueprint') {
               errors[key][index].addError('type must be set')
             }
           })


### PR DESCRIPTION
## What does this pull request change?
add validation on type

## Why is this pull request needed?
user should not be able to create invalid blueprint. type must one of attributeTypes enum values, except 'blueprint'

## Issues related to this change:
closes #330