### PR TITLE
fix attribute widget bug in type widget

### DIFF
--- a/api/home/core/SIMOS/BlueprintAttribute.json
+++ b/api/home/core/SIMOS/BlueprintAttribute.json
@@ -8,6 +8,7 @@
       "type": "system/SIMOS/BlueprintAttribute",
       "name": "type",
       "enumType": "system/SIMOS/AttributeTypes",
+      "default": "system/SIMOS/BlueprintAttribute",
       "optional": false
     },
     {
@@ -27,7 +28,6 @@
       "attributeType": "string",
       "type": "system/SIMOS/BlueprintAttribute",
       "name": "attributeType",
-      "default": "system/SIMOS/BlueprintAttribute",
       "optional": false
     },
     {

--- a/web/src/domain/BlueprintAttribute.ts
+++ b/web/src/domain/BlueprintAttribute.ts
@@ -24,9 +24,7 @@ export class BlueprintAttribute {
 
   public isPrimitiveType(value: string): boolean {
     // dont make this a static method. Needs to read attribute types later?
-    return ['string', 'number', 'integer', 'number', 'boolean'].includes(
-      this.getAttributeType()
-    )
+    return ['string', 'number', 'integer', 'number', 'boolean'].includes(value)
   }
 
   /**

--- a/web/src/plugins/form-rjsf-widgets/Attribute.tsx
+++ b/web/src/plugins/form-rjsf-widgets/Attribute.tsx
@@ -41,8 +41,9 @@ type Props = {
 export const AttributeWidget = (props: Props) => {
   let { attributes } = props.uiSchema
 
-  const initialState = { type: DataType.STRING, ...props.formData }
-  const [formData, setFormData] = useState<BlueprintAttributeType>(initialState)
+  const [formData, setFormData] = useState<BlueprintAttributeType>(
+    props.formData
+  )
 
   if (!attributes) {
     console.error('this widget depends on a attributes list.')

--- a/web/src/plugins/form-rjsf-widgets/AttributeInputs.tsx
+++ b/web/src/plugins/form-rjsf-widgets/AttributeInputs.tsx
@@ -118,8 +118,9 @@ export const TypeWidget = (props: TypeProps) => {
   const attr = new BlueprintAttribute(attributeType)
   const typeValue = attr.isPrimitiveType(value) ? value : DataType.BLUEPRINT
   const [selectedType, setSelectedType] = useState(
-    typeValue || attributeType.default
+    value ? typeValue : DataType.STRING
   )
+
   let blueprintValue
   if (typeValue === DataType.BLUEPRINT && value !== DataType.BLUEPRINT) {
     blueprintValue = value
@@ -129,7 +130,7 @@ export const TypeWidget = (props: TypeProps) => {
   return (
     <>
       <TypeDropdown
-        value={selectedType}
+        value={selectedType ? selectedType : DataType.BLUEPRINT}
         onChange={(event: any) => {
           setSelectedType(event.target.value)
           onChange(attributeType, event.target.value)


### PR DESCRIPTION

## What does this pull request change?
attribute widget set incorrect type since default in blueprint is wrong.
fix bug in isPrimitive not using argument.
attribute widget should not manipulate initial formData. logic moved to closer to where its needed.

## Why is this pull request needed?

## Issues related to this change:
#524 