### PR TITLE
improve error handling

### DIFF
--- a/api/classes/tree_node.py
+++ b/api/classes/tree_node.py
@@ -56,12 +56,28 @@ class DictImporter:
                     list_node.add_child(cls._from_dict(dto=DTO(uid=child.get("uid", ""), data=child), key=str(i)))
                 node.add_child(list_node)
             else:
-                if data := dto.data.get(attribute.name):
-                    node.add_child(cls._from_dict(dto=DTO(uid=data.get("uid", ""), data=data), key=attribute.name))
+                if attribute.name in dto.data:
+                    attribute_data = dto.data.get(attribute.name)
+                    node.add_child(cls._from_dict(dto=DTO(uid=attribute_data.get("uid", ""), data=attribute_data), key=attribute.name))
                 else:
-                    logger.warn(f"Data problem: {node}")
+                    # add empty error node.
+                    empty_data = {
+                        "name": attribute.name,
+                        "type": "",
+                        "uid": "",
+                        "errorMsg": "missing attribute",
+                        # blueprint is extracted in _from_dict method. name and type is needed since node from_dict is calling from_dict on the blueprint class.
+                        "_blueprint": {
+                            "name": "",
+                            "type": "",
+                        }
+                    }
+                    node.add_child(cls._from_dict(dto=DTO(uid=empty_data["uid"], data=empty_data), key=attribute.name))
+                    logger.warning(f"Data problem: {node}")
         return node
 
+def create_error_node(cls, attribute) -> Dict:
+    return cls._from_dict(dto=DTO(uid="", data={"name": attribute.name}), key="")
 
 class NodeBase:
     def __init__(self, key: str, dto: DTO = None, parent=None, children=None):

--- a/api/core/service/document_service.py
+++ b/api/core/service/document_service.py
@@ -46,7 +46,7 @@ def get_resolved_document(document: DTO, document_repository: Repository, bluepr
 
     for complex_attribute in blueprint.get_none_primitive_types():
         attribute_name = complex_attribute.name
-        if attribute_name in data and data[attribute_name]:
+        if attribute_name in data and data[attribute_name] is not None:
             storage_recipe: StorageRecipe = blueprint.storage_recipes[0]
             if storage_recipe.is_contained(attribute_name, complex_attribute.attribute_type):
                 if complex_attribute.is_array():

--- a/api/core/use_case/generate_index_use_case.py
+++ b/api/core/use_case/generate_index_use_case.py
@@ -98,7 +98,11 @@ def extend_index_with_node_tree(root: Union[Node, NodeBase], data_source_id: str
             if not is_visible(node):
                 continue
 
-            index[node.node_id] = get_node(node, data_source_id, application_page)
+            index_node = get_node(node, data_source_id, application_page)
+            if "errorMsg" in node.dto.data:
+                index[node.node_id] = get_error_node(node)
+            else:
+                index[node.node_id] = index_node
 
         except Exception as error:
             logger.exception(error)

--- a/api/tests/classes/test_tree_error_node.py
+++ b/api/tests/classes/test_tree_error_node.py
@@ -1,0 +1,42 @@
+import unittest
+
+from classes.dto import DTO
+from classes.tree_node import Node
+
+
+blueprint_1 = {
+    "type": "system/SIMOS/Blueprint",
+    "name": "Blueprint1",
+    "description": "First blueprint",
+    "attributes": [
+        {"attributeType": "string", "type": "system/SIMOS/BlueprintAttribute", "name": "name"},
+        {"attributeType": "string", "type": "system/SIMOS/BlueprintAttribute", "name": "type"},
+        {"attributeType": "string", "type": "system/SIMOS/BlueprintAttribute", "name": "description"},
+        {"attributeType": "blueprint_2", "type": "system/SIMOS/BlueprintAttribute", "name": "nested"},
+    ],
+    "storageRecipes": [],
+    "uiRecipes": [],
+}
+
+
+class ErrorTreenodeTestCase(unittest.TestCase):
+
+
+    def test_error_node_renamed(self):
+        document_1 = {
+            "uid": "1",
+            "name": "Parent",
+            "description": "",
+            "type": "blueprint_1",
+            # renamed nested to nested2
+            "nested2": {
+                "name": "Nested 1",
+                "description": "",
+                "type": "blueprint_2",
+
+            },
+            "_blueprint": blueprint_1,
+        }
+        root = Node.from_dict(DTO(document_1))
+        error_msg = root.children[0].dto.data["errorMsg"]
+        assert error_msg is not None

--- a/api/tests/classes/test_tree_node.py
+++ b/api/tests/classes/test_tree_node.py
@@ -150,6 +150,7 @@ class TreenodeTestCase(unittest.TestCase):
                         "type": "blueprint_2",
                         "_blueprint": blueprint_2,
                     },
+                    # wrong entity here. last nested is of type blueprint_3, which has name, type, description and reference, not _id, uid
                     "_blueprint": blueprint_3,
                 },
             },
@@ -158,7 +159,7 @@ class TreenodeTestCase(unittest.TestCase):
 
         root = Node.from_dict(DTO(document_1))
         result = [node.name for node in root.traverse()]
-        expected = ["Parent", "Nested 1", "Nested 2", "Reference", "references"]
+        expected = ["Parent", "Nested 1", "Nested 2", "Reference", "nested", "reference", "references"]
         assert result == expected
 
     def test_traverse_reverse(self):
@@ -331,9 +332,11 @@ class TreenodeTestCase(unittest.TestCase):
                         "name": "New name",
                         "type": "blueprint_2",
                         "description": "",
+                        "nested": {}
                     },
                 },
             },
+            "reference": {},
             "references": [],
         }
 


### PR DESCRIPTION
## What does this pull request change?
adds error_node to tree when attribute is renamed in blueprint. 
possible to handle other index failures by using errorMsg on the dto.data dict. 

## Why is this pull request needed?
Nodes should not disappear in the tree. 

## Issues related to this change:
#519 