### PR TITLE
move 'delete' to document_service, and use TreeNode

### DIFF
--- a/api/classes/tree_node.py
+++ b/api/classes/tree_node.py
@@ -1,7 +1,4 @@
-from typing import Union, Dict
-
-from core.use_case.utils.get_ui_recipe import get_recipe
-
+from typing import Union, Dict, List
 from classes.blueprint import Blueprint
 from classes.dto import DTO
 from utils.logging import logger
@@ -59,7 +56,7 @@ class DictImporter:
                 if data := dto.data.get(attribute.name):
                     node.add_child(cls._from_dict(dto=DTO(uid=data.get("uid", ""), data=data), key=attribute.name))
                 else:
-                    logger.warn(f"Data problem: {node}")
+                    logger.warning(f"Data problem: {node}")
         return node
 
 
@@ -211,6 +208,24 @@ class NodeBase:
 
     def has_children(self):
         return len(self.children) > 0
+
+    def delete_child(self, keys: List) -> None:
+        if len(keys) == 1:
+            for index, child in enumerate(self.children):
+                if child.key == keys[0]:
+                    self.children.pop(index)
+                    return
+        try:
+            next_node = next((x for x in self.children if x.key == keys[0]))
+        except StopIteration:
+            raise StopIteration(f"{keys[0]} not found on any children of {self.name}")
+        keys.pop(0)
+        next_node.delete_child(keys)
+
+    def remove_ref(self, target_id) -> None:
+        for i, c in enumerate(self.children):
+            if c.node_id == target_id:
+                self.children.pop(i)
 
 
 class Node(NodeBase):

--- a/api/core/rest/Explorer.py
+++ b/api/core/rest/Explorer.py
@@ -8,7 +8,7 @@ from core.shared import response_object as res
 from core.use_case.add_root_package_use_case import AddRootPackageUseCase, AddRootPackageRequestObject
 from core.use_case.export_use_case import ExportUseCase, ExportRequestObject
 from core.use_case.move_file_use_case import MoveFileUseCase, MoveFileRequestObject
-from core.use_case.remove_use_case import RemoveUseCase_v2, RemoveFileRequestObject_v2
+from core.use_case.remove_use_case import RemoveUseCase, RemoveFileRequestObject
 from core.use_case.rename_attribute_use_case import RenameAttributeUseCase, RenameAttributeRequestObject
 from core.use_case.rename_file_use_case import RenameFileUseCase, RenameFileRequestObject
 
@@ -40,8 +40,8 @@ def remove(data_source_id: str):
     db = DataSource(uid=data_source_id)
     request_data = request.get_json()
     document_repository = get_repository(db)
-    use_case = RemoveUseCase_v2(document_repository=document_repository)
-    request_object = RemoveFileRequestObject_v2.from_dict(request_data)
+    use_case = RemoveUseCase(document_repository=document_repository)
+    request_object = RemoveFileRequestObject.from_dict(request_data)
     response = use_case.execute(request_object)
     return Response(
         json.dumps(response.value, cls=DTOSerializer), mimetype="application/json", status=STATUS_CODES[response.type],

--- a/api/core/use_case/remove_use_case.py
+++ b/api/core/use_case/remove_use_case.py
@@ -1,14 +1,11 @@
-from classes.dto import DTO
 from core.repository import Repository
-from core.repository.repository_exceptions import EntityNotFoundException
+from core.service.document_service import DocumentService
 from core.shared import request_object as req
 from core.shared import response_object as res
 from core.shared import use_case as uc
-from core.use_case.utils.get_document_children import get_document_children
-from utils.logging import logger
 
 
-class RemoveFileRequestObject_v2(req.ValidRequestObject):
+class RemoveFileRequestObject(req.ValidRequestObject):
     def __init__(self, parent_id=None, document_id=None):
         self.parent_id = parent_id
         self.document_id = document_id
@@ -29,83 +26,24 @@ class RemoveFileRequestObject_v2(req.ValidRequestObject):
         return cls(parent_id=adict.get("parentId"), document_id=adict.get("documentId"))
 
 
-def remove_key_from_dto_data(key_path: list, data: dict) -> None:
-    if len(key_path) == 1:
-        if isinstance(data, list):
-            data.pop(int(key_path[0]))
-        elif isinstance(data, dict):
-            del data[key_path[0]]
-        return
-    if isinstance(data, list):
-        remove_key_from_dto_data(key_path, data[int(key_path.pop(0))])
-    elif isinstance(data, dict):
-        remove_key_from_dto_data(key_path, data[key_path.pop(0)])
-
-
-def remove_ref_from_parent(key_path: list, parent_data: dict, ref_id: str) -> None:
-    if len(key_path) == 1:
-        key = key_path[0]
-        if isinstance(parent_data[key], list):
-            for index, ref in enumerate(parent_data[key]):
-                if ref["_id"] == ref_id:
-                    parent_data[key].pop(index)
-                    break
-        elif isinstance(parent_data[key], dict):
-            raise Exception("Not implemented yet!")
-        return
-    if isinstance(parent_data, list):
-        remove_ref_from_parent(key_path, parent_data[int(key_path.pop(0))], ref_id)
-    elif isinstance(parent_data, dict):
-        remove_ref_from_parent(key_path, parent_data[key_path.pop(0)], ref_id)
-
-
-class RemoveUseCase_v2(uc.UseCase):
+class RemoveUseCase(uc.UseCase):
     def __init__(self, document_repository: Repository):
-        self.document_repository = document_repository
+        self.repository = document_repository
 
     def process_request(self, request_object):
-        document_id: str = request_object.document_id
-        parent_id: str = request_object.parent_id
-        split_document_id = document_id.split(".")
+        split_document_id: str = request_object.document_id.split(".")
+        split_parent_id: str = request_object.parent_id.split(".") if request_object.parent_id else None
+        document_id = split_document_id[0]
+        parent_id = None
+        parent_attribute_list = []
+        if split_parent_id:
+            parent_id = split_parent_id[0]
+            parent_attribute_list = split_parent_id[1:] if len(split_parent_id) > 1 else None
+        document_attribute_list = split_document_id[1:] if len(split_document_id) > 1 else None
 
-        # TODO: Can we avoid fetching the document here in some cases. F.eks when deleting a whole document.
-        document: DTO = self.document_repository.get(split_document_id[0])
-        if not document:
-            raise EntityNotFoundException(uid=split_document_id[0])
+        document_service = DocumentService()
+        document_service.remove_document(
+            document_id, self.repository, parent_id, parent_attribute_list, document_attribute_list
+        )
 
-        if parent_id:
-            split_parent = parent_id.split(".")
-            # If the attribute is in the same document. Just pop the attribute node.
-            if split_document_id[0] == split_parent[0]:
-                key_to_remove = split_document_id[1:]
-                remove_key_from_dto_data(key_to_remove, document.data)
-                self.document_repository.update(document)
-            # If it's not the same parent. We need to delete a reference as well as the document.
-            else:
-                # Remove reference from parent
-                parent: DTO = self.document_repository.get(split_parent[0])
-                if not parent:
-                    raise EntityNotFoundException(uid=parent_id)
-                remove_ref_from_parent(split_parent[1:], parent.data, document_id)
-                self.document_repository.update(parent)
-
-                # Remove the actual document
-                self.document_repository.delete(document.uid)
-
-                # Remove children of the document
-                children = get_document_children(document, self.document_repository)
-                for child in children:
-                    self.document_repository.delete(child.uid)
-                    logger.info(f"Removed child document '{child.uid}'")
-        else:
-            # Remove a node without any parent(root package)
-            self.document_repository.delete(document.uid)
-
-            # Remove children of the document
-            children = get_document_children(document, self.document_repository)
-            for child in children:
-                self.document_repository.delete(child.uid)
-                logger.info(f"Removed child document '{child.uid}'")
-
-        logger.info(f"Removed document '{document.uid}'")
         return res.ResponseSuccess(True)

--- a/api/tests/classes/test_tree_node.py
+++ b/api/tests/classes/test_tree_node.py
@@ -65,6 +65,25 @@ blueprint_3 = {
     "uiRecipes": [],
 }
 
+blueprint_4 = {
+    "type": "system/SIMOS/Blueprint",
+    "name": "Blueprint4",
+    "description": "Second blueprint",
+    "attributes": [
+        {"attributeType": "string", "type": "system/SIMOS/BlueprintAttribute", "name": "name"},
+        {"attributeType": "string", "type": "system/SIMOS/BlueprintAttribute", "name": "type"},
+        {"attributeType": "string", "type": "system/SIMOS/BlueprintAttribute", "name": "description"},
+        {
+            "attributeType": "blueprint_4",
+            "type": "system/SIMOS/BlueprintAttribute",
+            "name": "a_list",
+            "dimensions": "*",
+        },
+    ],
+    "storageRecipes": [],
+    "uiRecipes": [],
+}
+
 
 class TreenodeTestCase(unittest.TestCase):
     def test_is_root(self):
@@ -79,7 +98,7 @@ class TreenodeTestCase(unittest.TestCase):
         assert root.is_root()
         assert not nested.is_root()
 
-    def test_repace(self):
+    def test_replace(self):
         root_data = {"uid": 1, "name": "root", "description": "", "type": "blueprint_1"}
         root = Node(key="root", dto=DTO(uid="1", data=root_data), blueprint=Blueprint.from_dict(blueprint_1))
 
@@ -114,6 +133,153 @@ class TreenodeTestCase(unittest.TestCase):
         }
 
         assert actual_after_replaced == root.to_dict()
+
+    def test_delete_root_child(self):
+        root_data = {"uid": 1, "name": "root", "description": "", "type": "blueprint_1"}
+        root = Node(key="root", dto=DTO(uid="1", data=root_data), blueprint=Blueprint.from_dict(blueprint_1))
+
+        nested_1_data = {"name": "Nested 1", "description": "", "type": "blueprint_2"}
+        nested_1 = Node(
+            key="nested", dto=DTO(uid="", data=nested_1_data), blueprint=Blueprint.from_dict(blueprint_2), parent=root
+        )
+
+        actual_before = {
+            "_id": "1",
+            "uid": "1",
+            "name": "root",
+            "description": "",
+            "type": "blueprint_1",
+            "nested": {"name": "Nested 1", "description": "", "type": "blueprint_2"},
+        }
+
+        assert actual_before == root.to_dict()
+
+        root.delete_child(["nested"])
+
+        actual_after_delete = {"_id": "1", "uid": "1", "name": "root", "description": "", "type": "blueprint_1"}
+
+        assert actual_after_delete == root.to_dict()
+
+    def test_delete_nested_child(self):
+        root_data = {"uid": 1, "name": "root", "description": "", "type": "blueprint_1"}
+        root = Node(key="root", dto=DTO(uid="1", data=root_data), blueprint=Blueprint.from_dict(blueprint_1))
+
+        nested_1_data = {"name": "Nested 1", "description": "", "type": "blueprint_2"}
+        nested_1 = Node(
+            key="nested", dto=DTO(uid="", data=nested_1_data), blueprint=Blueprint.from_dict(blueprint_2), parent=root
+        )
+        nested_2_data = {"name": "Nested 2", "description": "", "type": "blueprint_3"}
+        nested_2 = Node(
+            key="nested2",
+            dto=DTO(uid="", data=nested_2_data),
+            blueprint=Blueprint.from_dict(blueprint_2),
+            parent=nested_1,
+        )
+
+        actual_before = {
+            "_id": "1",
+            "uid": "1",
+            "name": "root",
+            "description": "",
+            "type": "blueprint_1",
+            "nested": {
+                "name": "Nested 1",
+                "description": "",
+                "type": "blueprint_2",
+                "nested2": {"name": "Nested 2", "description": "", "type": "blueprint_3"},
+            },
+        }
+
+        assert actual_before == root.to_dict()
+
+        root.delete_child(["nested", "nested2"])
+
+        actual_after_delete = {
+            "_id": "1",
+            "uid": "1",
+            "name": "root",
+            "description": "",
+            "type": "blueprint_1",
+            "nested": {"name": "Nested 1", "description": "", "type": "blueprint_2"},
+        }
+
+        assert actual_after_delete == root.to_dict()
+
+    def test_delete_list_element_of_nested_child(self):
+        document = {
+            "_id": "1",
+            "uid": "1",
+            "name": "root",
+            "description": "",
+            "type": "blueprint_4",
+            "_blueprint": blueprint_4,
+            "a_list": [
+                {
+                    "name": "Nested 1",
+                    "description": "",
+                    "type": "blueprint_4",
+                    "_blueprint": blueprint_4,
+                    "a_list": [
+                        {
+                            "name": "Nested 2 index 0",
+                            "description": "",
+                            "type": "blueprint_4",
+                            "_blueprint": blueprint_4,
+                            "a_list": [],
+                        },
+                        {
+                            "name": "Nested 2 index 1",
+                            "description": "",
+                            "type": "blueprint_4",
+                            "_blueprint": blueprint_4,
+                            "a_list": [],
+                        },
+                    ],
+                }
+            ],
+        }
+        root = Node.from_dict(DTO(document))
+
+        actual_before = {
+            "_id": "1",
+            "uid": "1",
+            "name": "root",
+            "description": "",
+            "type": "blueprint_4",
+            "a_list": [
+                {
+                    "name": "Nested 1",
+                    "description": "",
+                    "type": "blueprint_4",
+                    "a_list": [
+                        {"name": "Nested 2 index 0", "description": "", "type": "blueprint_4", "a_list": []},
+                        {"name": "Nested 2 index 1", "description": "", "type": "blueprint_4", "a_list": []},
+                    ],
+                }
+            ],
+        }
+
+        assert actual_before == root.to_dict()
+
+        root.delete_child(["a_list", "0", "a_list", "1"])
+
+        actual_after_delete = {
+            "_id": "1",
+            "uid": "1",
+            "name": "root",
+            "description": "",
+            "type": "blueprint_4",
+            "a_list": [
+                {
+                    "name": "Nested 1",
+                    "description": "",
+                    "type": "blueprint_4",
+                    "a_list": [{"name": "Nested 2 index 0", "description": "", "type": "blueprint_4", "a_list": []}],
+                }
+            ],
+        }
+
+        assert actual_after_delete == root.to_dict()
 
     def test_depth(self):
         root_data = {"uid": 1, "name": "root", "description": "", "type": "blueprint_1"}


### PR DESCRIPTION
## What does this pull request change?
* Move the delete_use_case logic to "document_service"
* Utilize TreeNode to manipulate data structure

## Why is this pull request needed?
* Centralize logic in document_service and around Tree structure.

## Issues related to this change:
