### PR TITLE
fix default name on nested entities #535

### DIFF
--- a/api/core/use_case/utils/create_entity.py
+++ b/api/core/use_case/utils/create_entity.py
@@ -104,6 +104,10 @@ class CreateEntity:
             if attr.attribute_type in PRIMITIVES:
                 if is_optional is not None and not is_optional:
                     default_value = CreateEntity.default_value(attr=attr, parent_type=parent_type)
+
+                    if attr.name == "name" and len(default_value) == 0:
+                        default_value = parent_type.split('/')[-1].lower()
+
                     if attr.name not in entity:
                         entity[attr.name] = default_value
             else:

--- a/api/tests/core/use_case/utils/test_create_entity.py
+++ b/api/tests/core/use_case/utils/test_create_entity.py
@@ -22,7 +22,7 @@ class CreateEntityTestCase(unittest.TestCase):
             "engine": {
                 "description": "",
                 "fuelPump": {
-                    "name": "",
+                    "name": "fuelpumptest",
                     "description": "A standard fuel pump",
                     "type": "ds/test_data/complex/FuelPumpTest",
                 },


### PR DESCRIPTION
## What does this pull request change?
set name in nested entities

## Why is this pull request needed?
when creating a new car, only the new car's name is set based on input from the user.
Nested entities that does not have default name set in the blueprint will have nodes without a title, which makes the index nodes unclickable.

To avoid adding default name on every blueprint that exists, nested entities get name from its type.

## Issues related to this change:
#535