### PR TITLE
Move repository logic to handle multiple data sources

### DIFF
--- a/api/core/repository/__init__.py
+++ b/api/core/repository/__init__.py
@@ -5,9 +5,10 @@ from core.repository.db_client_interface import DBClientInterface
 
 
 class Repository:
-    def __init__(self, name: str, db: DBClientInterface):
+    def __init__(self, name: str, db: DBClientInterface, document_type: str):
         self.name = name
         self.client = db
+        self.document_type = document_type
 
     def get(self, uid: str) -> DTO:
         result = self.client.get(uid)

--- a/api/core/repository/repository_factory.py
+++ b/api/core/repository/repository_factory.py
@@ -4,7 +4,8 @@ from core.repository import Repository
 from core.repository.mongo import MongoDBClient
 
 
-def get_repository(data_source: DataSource):
+def get_repository(data_source_id: str):
+    data_source: DataSource = DataSource(uid=data_source_id)
     if data_source.type == DataSourceType.MONGO.value:
         return Repository(
             name=data_source.name,
@@ -17,4 +18,5 @@ def get_repository(data_source: DataSource):
                 collection=data_source.collection,
                 port=data_source.port,
             ),
+            document_type=data_source.documentType,
         )

--- a/api/core/rest/Document.py
+++ b/api/core/rest/Document.py
@@ -1,13 +1,12 @@
 import json
-from flask import Blueprint, Response, request
-from classes.data_source import DataSource
+
 from core.serializers.dto_json_serializer import DTOSerializer
-from core.use_case.generate_json_schema_use_case import GenerateJsonSchemaUseCase, GenerateJsonSchemaRequestObject
-from utils.logging import logger
-from core.use_case.get_document_use_case import GetDocumentUseCase, GetDocumentRequestObject
 from core.shared import response_object as res
-from core.repository.repository_factory import get_repository
+from core.use_case.generate_json_schema_use_case import GenerateJsonSchemaUseCase, GenerateJsonSchemaRequestObject
+from core.use_case.get_document_use_case import GetDocumentUseCase, GetDocumentRequestObject
 from core.use_case.update_document_use_case import UpdateDocumentUseCase, UpdateDocumentRequestObject
+from flask import Blueprint, Response, request
+from utils.logging import logger
 
 blueprint = Blueprint("document", __name__)
 
@@ -29,19 +28,16 @@ def get_json_schema(type: str):
     return Response(json.dumps(response.value), mimetype="application/json", status=STATUS_CODES[response.type])
 
 
-@blueprint.route("/api/v2/documents/<string:data_source_id>/<document_path>", methods=["GET"])
-def get(data_source_id: str, document_path: str):
-    logger.info(f"Getting document '{document_path}' from data source '{data_source_id}'")
+@blueprint.route("/api/v2/documents/<string:data_source_id>/<document_id>", methods=["GET"])
+def get(data_source_id: str, document_id: str):
+    logger.info(f"Getting document '{document_id}' from data source '{data_source_id}'")
     ui_recipe = request.args.get("ui_recipe")
     attribute = request.args.get("attribute")
-    data_source = DataSource(uid=data_source_id)
-    document_repository = get_repository(data_source)
-    use_case = GetDocumentUseCase(document_repository)
+    use_case = GetDocumentUseCase()
     request_object = GetDocumentRequestObject.from_dict(
-        {"document_id": document_path, "ui_recipe": ui_recipe, "attribute": attribute}
+        {"data_source_id": data_source_id, "document_id": document_id, "ui_recipe": ui_recipe, "attribute": attribute}
     )
     response = use_case.execute(request_object)
-    # TODO: Use DTOSerializer?
     return Response(json.dumps(response.value), mimetype="application/json", status=STATUS_CODES[response.type])
 
 
@@ -50,12 +46,10 @@ def put(data_source_id: str, document_id: str):
     logger.info(f"Updating document '{document_id}' in data source '{data_source_id}'")
     data = request.get_json()
     attribute = request.args.get("attribute")
-    data_source = DataSource(uid=data_source_id)
-    document_repository = get_repository(data_source)
     request_object = UpdateDocumentRequestObject.from_dict(
-        {"data": data, "document_id": document_id, "attribute": attribute}
+        {"data_source_id": data_source_id, "data": data, "document_id": document_id, "attribute": attribute}
     )
-    update_use_case = UpdateDocumentUseCase(document_repository)
+    update_use_case = UpdateDocumentUseCase()
     response = update_use_case.execute(request_object)
     return Response(
         json.dumps(response.value, cls=DTOSerializer), mimetype="application/json", status=STATUS_CODES[response.type]

--- a/api/core/rest/Explorer.py
+++ b/api/core/rest/Explorer.py
@@ -1,16 +1,16 @@
 import json
-from flask import Blueprint, Response, request, send_file
-from classes.data_source import DataSource
+
 from core.repository.repository_factory import get_repository
 from core.serializers.dto_json_serializer import DTOSerializer
-from core.use_case.add_file_use_case import AddFileUseCase, AddFileRequestObject
 from core.shared import response_object as res
+from core.use_case.add_file_use_case import AddFileUseCase, AddFileRequestObject
 from core.use_case.add_root_package_use_case import AddRootPackageUseCase, AddRootPackageRequestObject
 from core.use_case.export_use_case import ExportUseCase, ExportRequestObject
 from core.use_case.move_file_use_case import MoveFileUseCase, MoveFileRequestObject
 from core.use_case.remove_use_case import RemoveUseCase, RemoveFileRequestObject
 from core.use_case.rename_attribute_use_case import RenameAttributeUseCase, RenameAttributeRequestObject
 from core.use_case.rename_file_use_case import RenameFileUseCase, RenameFileRequestObject
+from flask import Blueprint, Response, request, send_file
 
 blueprint = Blueprint("explorer", __name__)
 
@@ -24,10 +24,9 @@ STATUS_CODES = {
 
 @blueprint.route("/api/v2/explorer/<string:data_source_id>/add-file", methods=["POST"])
 def add_file(data_source_id: str):
-    data_source = DataSource(uid=data_source_id)
     request_data = request.get_json()
-    document_repository = get_repository(data_source)
-    use_case = AddFileUseCase(document_repository=document_repository)
+    request_data["data_source_id"] = data_source_id
+    use_case = AddFileUseCase()
     request_object = AddFileRequestObject.from_dict(request_data)
     response = use_case.execute(request_object)
     return Response(
@@ -37,10 +36,9 @@ def add_file(data_source_id: str):
 
 @blueprint.route("/api/v4/explorer/<string:data_source_id>/remove", methods=["POST"])
 def remove(data_source_id: str):
-    db = DataSource(uid=data_source_id)
     request_data = request.get_json()
-    document_repository = get_repository(db)
-    use_case = RemoveUseCase(document_repository=document_repository)
+    request_data["data_source_id"] = data_source_id
+    use_case = RemoveUseCase()
     request_object = RemoveFileRequestObject.from_dict(request_data)
     response = use_case.execute(request_object)
     return Response(
@@ -50,10 +48,9 @@ def remove(data_source_id: str):
 
 @blueprint.route("/api/v2/explorer/<string:data_source_id>/rename-attribute", methods=["PUT"])
 def rename_attribute(data_source_id: str):
-    db = DataSource(uid=data_source_id)
     request_data = request.get_json()
-    document_repository = get_repository(db)
-    use_case = RenameAttributeUseCase(document_repository=document_repository)
+    request_data["data_source_id"] = data_source_id
+    use_case = RenameAttributeUseCase()
     request_object = RenameAttributeRequestObject.from_dict(request_data)
     response = use_case.execute(request_object)
     return Response(
@@ -74,11 +71,8 @@ def move_file():
 
 @blueprint.route("/api/v2/explorer/<string:data_source_id>/add-root-package", methods=["POST"])
 def add_root_package(data_source_id: str):
-    db = DataSource(uid=data_source_id)
     request_data = request.get_json()
-
-    document_repository = get_repository(db)
-
+    document_repository = get_repository(data_source_id)
     use_case = AddRootPackageUseCase(document_repository=document_repository)
     request_object = AddRootPackageRequestObject.from_dict(request_data)
     response = use_case.execute(request_object)
@@ -90,10 +84,9 @@ def add_root_package(data_source_id: str):
 
 @blueprint.route("/api/v2/explorer/<string:data_source_id>/rename-file", methods=["PUT"])
 def rename_file(data_source_id: str):
-    db = DataSource(uid=data_source_id)
     request_data = request.get_json()
-    document_repository = get_repository(db)
-    use_case = RenameFileUseCase(document_repository=document_repository)
+    request_data["data_source_id"] = data_source_id
+    use_case = RenameFileUseCase()
     request_object = RenameFileRequestObject.from_dict(request_data)
     response = use_case.execute(request_object)
     return Response(
@@ -103,10 +96,8 @@ def rename_file(data_source_id: str):
 
 @blueprint.route("/api/v2/explorer/<string:data_source_id>/export/<string:document_id>", methods=["GET"])
 def post(data_source_id: str, document_id: str):
-    data_source = DataSource(uid=data_source_id)
-    document_repository = get_repository(data_source)
-    request_object = ExportRequestObject.from_dict({"documentId": document_id})
-    use_case = ExportUseCase(document_repository)
+    request_object = ExportRequestObject.from_dict({"data_source_id": data_source_id, "documentId": document_id})
+    use_case = ExportUseCase()
     response = use_case.execute(request_object)
 
     if response.type == res.ResponseSuccess.SUCCESS:

--- a/api/core/rest/Index.py
+++ b/api/core/rest/Index.py
@@ -1,37 +1,29 @@
 import json
 
-from flask import Blueprint, Response
-
-from classes.data_source import DataSource
 from core.repository.repository_factory import get_repository
 from core.use_case.generate_index_use_case import GenerateIndexUseCase as GenerateIndexUseCase
+from flask import Blueprint, Response
 
 blueprint = Blueprint("index", __name__)
 
 
 @blueprint.route("/api/v4/index/<string:data_source_id>", methods=["GET"])
 def get_v2(data_source_id: str):
-    data_source = DataSource(uid=data_source_id)
-    document_repository = get_repository(data_source)
+    document_repository = get_repository(data_source_id)
     use_case = GenerateIndexUseCase()
-    result = use_case.execute(
-        data_source_id=data_source_id,
-        document_repository=document_repository,
-        application_page=data_source.documentType,
-    )
+    result = use_case.execute(data_source_id=data_source_id, application_page=document_repository.document_type,)
     return Response(json.dumps(result), mimetype="application/json", status=200)
 
 
 @blueprint.route("/api/v4/index/<string:data_source_id>/<string:parent_id>/<string:document_id>", methods=["GET"])
 def get_single_index_v2(data_source_id: str, parent_id: str, document_id: str):
-    data_source = DataSource(uid=data_source_id)
-    document_repository = get_repository(data_source)
+    document_repository = get_repository(data_source_id)
 
     use_case = GenerateIndexUseCase()
     result = use_case.single(
-        document_repository=document_repository,
+        data_source_id=data_source_id,
         document_id=document_id,
-        application_page=data_source.documentType,
+        application_page=document_repository.document_type,
         parent_id=parent_id,
     )
 

--- a/api/core/service/document_service.py
+++ b/api/core/service/document_service.py
@@ -2,20 +2,20 @@ from pyclbr import Function
 from typing import Dict, List
 
 import stringcase
+from core.enums import DMT, SIMOS
+from core.repository import Repository
+from core.repository.repository_exceptions import EntityAlreadyExistsException, EntityNotFoundException
+from core.use_case.utils.create_entity import CreateEntity
+from core.utility import get_blueprint
 from dotted.collection import DottedDict
+from utils.data_structure.find import get
+from utils.logging import logger
 
 from classes.blueprint import Blueprint
 from classes.blueprint_attribute import BlueprintAttribute
 from classes.dto import DTO
 from classes.storage_recipe import StorageRecipe
 from classes.tree_node import Node
-from core.enums import DMT, SIMOS
-from core.repository import Repository
-from core.repository.repository_exceptions import EntityAlreadyExistsException, EntityNotFoundException
-from core.use_case.utils.create_entity import CreateEntity
-from core.utility import get_blueprint
-from utils.data_structure.find import get
-from utils.logging import logger
 
 
 def create_reference(data: Dict, document_repository, type: str):
@@ -78,30 +78,35 @@ def get_complete_document(
 
 
 class DocumentService:
-    def __init__(self, document_repository: Repository, blueprint_provider=get_blueprint):
+    def __init__(self, repository_provider, blueprint_provider=get_blueprint):
         self.blueprint_provider = blueprint_provider
-        self.document_repository = document_repository
+        self.repository_provider = repository_provider
 
-    def get_by_uid(self, document_uid: str) -> Node:
+    def get_by_uid(self, data_source_id: str, document_uid: str) -> Node:
         node = Node.from_dict(
-            DTO(get_complete_document(document_uid, self.document_repository, self.blueprint_provider))
+            DTO(get_complete_document(document_uid, self.repository_provider(data_source_id), self.blueprint_provider))
         )
         return node
 
-    def rename_attribute(self, parent_id: str, attribute: List[str], name: str):
-        node: Node = self.get_by_uid(document_uid=parent_id)
+    def get_root_packages(self, data_source_id: str):
+        return self.repository_provider(data_source_id).find(
+            {"type": "system/DMT/Package", "isRoot": True}, single=False
+        )
+
+    def rename_attribute(self, data_source_id: str, parent_id: str, attribute: List[str], name: str):
+        node: Node = self.get_by_uid(data_source_id=data_source_id, document_uid=parent_id)
         attribute_node_id = f"{parent_id}.{attribute}"
         attribute_node = node.search(attribute_node_id)
         attribute_node.update({"name": name})
         node.replace(attribute_node_id, attribute_node)
         document = DTO(node.to_dict())
-        self.document_repository.update(document)
+        self.repository_provider(data_source_id).update(document)
         logger.info(f"Rename attribute '{attribute}' from '{node.node_id}'")
         return document
 
-    def remove_document(self, document_id: str, parent_id: str = None):
+    def remove_document(self, data_source_id: str, document_id: str, parent_id: str = None):
         if parent_id:
-            parent: Node = self.get_by_uid(parent_id)
+            parent: Node = self.get_by_uid(data_source_id, parent_id)
 
             if not parent:
                 raise EntityNotFoundException(uid=parent_id)
@@ -112,36 +117,36 @@ class DocumentService:
                 raise EntityNotFoundException(uid=document_id)
 
             if attribute_node.has_uid():
-                self._remove_document(document_id)
+                self._remove_document(data_source_id, document_id)
 
             attribute_node.remove()
 
-            self.document_repository.update(DTO(parent.to_dict()))
+            self.repository_provider(data_source_id).update(DTO(parent.to_dict()))
         else:
-            self._remove_document(document_id)
+            self._remove_document(data_source_id, document_id)
 
-    def _remove_document(self, document_id):
-        document: Node = self.get_by_uid(document_id)
+    def _remove_document(self, data_source_id, document_id):
+        document: Node = self.get_by_uid(data_source_id, document_id)
         if not document:
             raise EntityNotFoundException(uid=document_id)
 
         # Remove the actual document
-        self.document_repository.delete(document.node_id)
+        self.repository_provider(data_source_id).delete(document.node_id)
         logger.info(f"Removed document '{document.node_id}'")
 
         # Remove child references
         for child in document.traverse():
             if child.has_uid():
-                self.document_repository.delete(child.uid)
+                self.repository_provider(data_source_id).delete(child.uid)
                 logger.info(f"Removed child '{child.uid}'")
 
-    def rename_document(self, document_id: str, parent_id: str, name: str, attribute: str):
-        document: DTO = self.document_repository.get(document_id)
+    def rename_document(self, data_source_id: str, document_id: str, parent_id: str, name: str, attribute: str):
+        document: DTO = self.repository_provider(data_source_id).get(document_id)
         if not document:
             raise EntityNotFoundException(document_id)
 
         if parent_id:
-            parent_document: DTO = self.document_repository.get(parent_id)
+            parent_document: DTO = self.repository_provider(data_source_id).get(parent_id)
             if not parent_document:
                 raise EntityNotFoundException(parent_id)
 
@@ -156,13 +161,13 @@ class DocumentService:
             parent_document[attribute].append(reference)
 
         document.name = name
-        self.document_repository.update(document)
+        self.repository_provider(data_source_id).update(document)
 
         logger.info(f"Rename document '{document.uid}' to '{name}")
 
         return document
 
-    def update_document(self, document_id: str, data: dict, attribute: str):
+    def update_document(self, data_source_id: str, document_id: str, data: dict, attribute: str):
         def update_attribute(attribute, data: BlueprintAttribute, storage_recipe: StorageRecipe, document_repository):
             is_contained_in_storage = storage_recipe.is_contained(attribute.name, attribute.attribute_type)
             attribute_data = data[attribute.name]
@@ -182,7 +187,7 @@ class DocumentService:
                     return reference
 
         def update_document(document_id, data: Dict, document_repository: Repository) -> DTO:
-            document: DTO = document_repository.get(document_id)
+            document: DTO = document_repository.get(uid=document_id)
 
             if not document:
                 raise EntityNotFoundException(uid=document_id)
@@ -204,25 +209,27 @@ class DocumentService:
             return document
 
         if attribute:
-            existing_data: DTO = self.document_repository.get(document_id).data
+            existing_data: DTO = self.repository_provider(data_source_id).get(document_id).data
             if not existing_data:
                 raise EntityNotFoundException(uid=document_id)
             dotted_data = DottedDict(existing_data)
             dotted_data[attribute] = data
             data = dotted_data.to_python()
 
-        document = update_document(document_id, data, self.document_repository)
+        document = update_document(document_id, data, self.repository_provider(data_source_id))
 
-        self.document_repository.update(document)
+        self.repository_provider(data_source_id).update(document)
 
         logger.info(f"Updated document '{document.uid}''")
 
         return document
 
-    def add_document(self, parent_id: str, type: str, name: str, description: str, attribute_dot_path: str):
+    def add_document(
+        self, data_source_id: str, parent_id: str, type: str, name: str, description: str, attribute_dot_path: str
+    ):
         attribute: str = stringcase.snakecase(attribute_dot_path)
 
-        parent: DTO = self.document_repository.get(parent_id)
+        parent: DTO = self.repository_provider(data_source_id).get(parent_id)
         if not parent:
             raise EntityNotFoundException(uid=parent_id)
 
@@ -268,7 +275,7 @@ class DocumentService:
             else:
                 getattr(parent_data, attribute).append(entity)
                 logger.info(f"Added contained document")
-            self.document_repository.update(parent)
+            self.repository_provider(data_source_id).update(parent)
             new_id = f"{parent_id}.{attribute_dot_path}.{len(dotted_data[attribute_dot_path]) - 1}"
             return {"uid": new_id}
         else:
@@ -289,7 +296,7 @@ class DocumentService:
             if type == SIMOS.BLUEPRINT.value:
                 file.data["attributes"] = get_required_attributes(type=type)
             get(parent_data, attribute).append({"_id": file.uid, "name": name, "type": type})
-            self.document_repository.add(file)
+            self.repository_provider(data_source_id).add(file)
             logger.info(f"Added document '{file.uid}''")
-            self.document_repository.update(parent)
+            self.repository_provider(data_source_id).update(parent)
             return file

--- a/api/core/use_case/add_file_use_case.py
+++ b/api/core/use_case/add_file_use_case.py
@@ -1,13 +1,24 @@
-from core.repository import Repository
 from core.shared import request_object as req
 from core.shared import response_object as res
 from core.shared import use_case as uc
-from core.utility import get_blueprint
 from core.service.document_service import DocumentService
+
+from core.repository.repository_factory import get_repository
 
 
 class AddFileRequestObject(req.ValidRequestObject):
-    def __init__(self, parent_id=None, name=None, description=None, type=None, attribute=None, path=None, data=None):
+    def __init__(
+        self,
+        data_source_id=None,
+        parent_id=None,
+        name=None,
+        description=None,
+        type=None,
+        attribute=None,
+        path=None,
+        data=None,
+    ):
+        self.data_source_id = data_source_id
         self.parent_id = parent_id
         self.name = name
         self.description = description
@@ -19,6 +30,9 @@ class AddFileRequestObject(req.ValidRequestObject):
     @classmethod
     def from_dict(cls, adict):
         invalid_req = req.InvalidRequestObject()
+
+        if "data_source_id" not in adict:
+            invalid_req.add_error("data_source_id", "is missing")
 
         if "parentId" not in adict:
             invalid_req.add_error("parentId", "is missing")
@@ -36,6 +50,7 @@ class AddFileRequestObject(req.ValidRequestObject):
             return invalid_req
 
         return cls(
+            data_source_id=adict.get("data_source_id"),
             parent_id=adict.get("parentId"),
             name=adict.get("name"),
             description=adict.get("description", ""),
@@ -46,29 +61,26 @@ class AddFileRequestObject(req.ValidRequestObject):
         )
 
 
-class BlueprintProvider:
-    def __init__(self, document_repository):
-        self.document_repository = document_repository
-
-    def get_blueprint(self, type: str):
-        return get_blueprint(type)
-
-
 class AddFileUseCase(uc.UseCase):
-    def __init__(self, document_repository: Repository):
-        self.document_repository = document_repository
-        self.blueprint_provider = BlueprintProvider(document_repository=self.document_repository)
+    def __init__(self, repository_provider=get_repository):
+        self.repository_provider = repository_provider
 
     def process_request(self, request_object: AddFileRequestObject):
+        data_source_id = request_object.data_source_id
         parent_id: str = request_object.parent_id
         name: str = request_object.name
         type: str = request_object.type
         description: str = request_object.description
         attribute_dot_path = request_object.attribute
 
-        document_service = DocumentService(document_repository=self.document_repository)
+        document_service = DocumentService(repository_provider=self.repository_provider)
         document = document_service.add_document(
-            parent_id=parent_id, type=type, name=name, description=description, attribute_dot_path=attribute_dot_path
+            data_source_id=data_source_id,
+            parent_id=parent_id,
+            type=type,
+            name=name,
+            description=description,
+            attribute_dot_path=attribute_dot_path,
         )
 
         return res.ResponseSuccess(document)

--- a/api/core/use_case/generate_index_use_case.py
+++ b/api/core/use_case/generate_index_use_case.py
@@ -1,17 +1,17 @@
 from typing import Dict, Union
 
-from core.repository.repository_exceptions import EntityNotFoundException
-
-from classes.dto import DTO
-from classes.tree_node import Node, NodeBase
-from config import Config
 from core.enums import DMT
-from core.repository import Repository
+from core.repository.repository_exceptions import EntityNotFoundException
+from core.repository.repository_factory import get_repository
 from core.service.document_service import DocumentService
 from core.use_case.utils.generate_index_menu_actions_v2 import get_node_on_select
 from core.use_case.utils.get_ui_recipe import get_recipe
 from core.use_case.utils.set_index_context_menu import create_context_menu
 from utils.logging import logger
+
+from classes.dto import DTO
+from classes.tree_node import Node, NodeBase
+from config import Config
 
 
 def get_error_node(node: Union[Node]) -> Dict:
@@ -113,23 +113,24 @@ def extend_index_with_node_tree(root: Union[Node, NodeBase], data_source_id: str
 
 
 class GenerateIndexUseCase:
-    @staticmethod
-    def execute(data_source_id: str, document_repository: Repository, application_page: str) -> dict:
-        root_packages = document_repository.find({"type": "system/DMT/Package", "isRoot": True}, single=False)
+    def __init__(self, repository_provider=get_repository):
+        self.repository_provider = repository_provider
+
+    def execute(self, data_source_id: str, application_page: str) -> dict:
+        document_service = DocumentService(repository_provider=self.repository_provider)
+        root_packages = document_service.get_root_packages(data_source_id=data_source_id)
         root = NodeBase(key="root", dto=DTO(uid=data_source_id, data={"type": "datasource", "name": data_source_id}))
-        document_service = DocumentService(document_repository=document_repository)
         for root_package in root_packages:
-            root.add_child(document_service.get_by_uid(document_uid=root_package.uid))
+            root.add_child(document_service.get_by_uid(data_source_id=data_source_id, document_uid=root_package.uid))
         root.show_tree()
         return extend_index_with_node_tree(root, data_source_id, application_page)
 
-    def single(self, document_repository: Repository, document_id: str, application_page: str, parent_id: str) -> Dict:
-        data_source_id = document_repository.name
+    def single(self, data_source_id: str, document_id: str, application_page: str, parent_id: str) -> Dict:
         app_settings = (
             Config.DMT_APPLICATION_SETTINGS if application_page == "blueprints" else Config.ENTITY_APPLICATION_SETTINGS
         )
-        document_service = DocumentService(document_repository=document_repository)
-        parent = document_service.get_by_uid(document_uid=parent_id.split(".", 1)[0])
+        document_service = DocumentService(repository_provider=self.repository_provider)
+        parent = document_service.get_by_uid(data_source_id=data_source_id, document_uid=parent_id.split(".", 1)[0])
         if not parent:
             raise EntityNotFoundException(uid=parent_id)
         parent.show_tree()

--- a/api/core/use_case/rename_attribute_use_case.py
+++ b/api/core/use_case/rename_attribute_use_case.py
@@ -1,13 +1,13 @@
+from core.repository.repository_factory import get_repository
 from core.service.document_service import DocumentService
-
-from core.repository import Repository
 from core.shared import request_object as req
 from core.shared import response_object as res
 from core.shared import use_case as uc
 
 
 class RenameAttributeRequestObject(req.ValidRequestObject):
-    def __init__(self, name=None, parent_id=None, attribute=None):
+    def __init__(self, data_source_id=None, name=None, parent_id=None, attribute=None):
+        self.data_source_id = data_source_id
         self.name = name
         self.parent_id = parent_id
         self.attribute = attribute
@@ -15,6 +15,9 @@ class RenameAttributeRequestObject(req.ValidRequestObject):
     @classmethod
     def from_dict(cls, adict):
         invalid_req = req.InvalidRequestObject()
+
+        if "data_source_id" not in adict:
+            invalid_req.add_error("data_source_id", "is missing")
 
         if "parentId" not in adict:
             invalid_req.add_error("parentId", "is missing")
@@ -28,19 +31,25 @@ class RenameAttributeRequestObject(req.ValidRequestObject):
         if invalid_req.has_errors():
             return invalid_req
 
-        return cls(name=adict.get("name"), parent_id=adict.get("parentId"), attribute=adict.get("attribute"),)
+        return cls(
+            data_source_id=adict.get("data_source_id"),
+            name=adict.get("name"),
+            parent_id=adict.get("parentId"),
+            attribute=adict.get("attribute"),
+        )
 
 
 class RenameAttributeUseCase(uc.UseCase):
-    def __init__(self, document_repository: Repository):
-        self.document_repository = document_repository
+    def __init__(self, repository_provider=get_repository):
+        self.repository_provider = repository_provider
 
     def process_request(self, request_object: RenameAttributeRequestObject):
+        data_source_id: str = request_object.data_source_id
         name = request_object.name
         parent_id = request_object.parent_id
         attribute = request_object.attribute
 
-        document_service = DocumentService(document_repository=self.document_repository)
-        document = document_service.rename_attribute(parent_id, attribute, name)
+        document_service = DocumentService(repository_provider=self.repository_provider)
+        document = document_service.rename_attribute(data_source_id, parent_id, attribute, name)
 
         return res.ResponseSuccess(document)

--- a/api/core/use_case/update_document_use_case.py
+++ b/api/core/use_case/update_document_use_case.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from core.repository import Repository
+from core.repository.repository_factory import get_repository
 from core.service.document_service import DocumentService
 from core.shared import request_object as req
 from core.shared import response_object as res
@@ -8,7 +8,8 @@ from core.shared import use_case as uc
 
 
 class UpdateDocumentRequestObject(req.ValidRequestObject):
-    def __init__(self, document_id=None, data=None, attribute=None):
+    def __init__(self, data_source_id=None, document_id=None, data=None, attribute=None):
+        self.data_source_id = data_source_id
         self.data = data
         self.document_id = document_id
         self.attribute = attribute
@@ -16,6 +17,9 @@ class UpdateDocumentRequestObject(req.ValidRequestObject):
     @classmethod
     def from_dict(cls, adict):
         invalid_req = req.InvalidRequestObject()
+
+        if "data_source_id" not in adict:
+            invalid_req.add_error("data_source_id", "is missing")
 
         if "document_id" not in adict:
             invalid_req.add_error("document_id", "is missing")
@@ -26,19 +30,28 @@ class UpdateDocumentRequestObject(req.ValidRequestObject):
         if invalid_req.has_errors():
             return invalid_req
 
-        return cls(data=adict.get("data"), document_id=adict.get("document_id"), attribute=adict.get("attribute"))
+        return cls(
+            data_source_id=adict.get("data_source_id"),
+            data=adict.get("data"),
+            document_id=adict.get("document_id"),
+            attribute=adict.get("attribute"),
+        )
 
 
 class UpdateDocumentUseCase(uc.UseCase):
-    def __init__(self, document_repository: Repository):
-        self.document_repository = document_repository
+    def __init__(self, repository_provider=get_repository):
+        self.repository_provider = repository_provider
 
     def process_request(self, request_object: UpdateDocumentRequestObject):
+        data_source_id = request_object.data_source_id
         document_id: str = request_object.document_id
         data: Dict = request_object.data
         attribute: Dict = request_object.attribute
+        data_source_id: str = request_object.data_source_id
 
-        document_service = DocumentService(document_repository=self.document_repository)
-        document = document_service.update_document(document_id=document_id, data=data, attribute=attribute)
+        document_service = DocumentService(repository_provider=self.repository_provider)
+        document = document_service.update_document(
+            data_source_id=data_source_id, document_id=document_id, data=data, attribute=attribute
+        )
 
         return res.ResponseSuccess(document)

--- a/api/core/utility.py
+++ b/api/core/utility.py
@@ -1,15 +1,15 @@
 from functools import lru_cache
 from typing import List, Union
 
-from classes.blueprint import Blueprint
-from classes.data_source import DataSource
-from config import Config
-from classes.dto import DTO
 from core.repository.repository_exceptions import EntityNotFoundException
 from core.repository.repository_factory import get_repository
-from services.database import dmt_database
 from utils.helper_functions import get_data_source_and_path, get_package_and_path
 from utils.logging import logger
+
+from classes.blueprint import Blueprint
+from classes.dto import DTO
+from config import Config
+from services.database import dmt_database
 
 
 def _find_document_in_package_by_path(package: DTO, path_elements: List[str], repository) -> Union[str, dict, None]:
@@ -51,8 +51,7 @@ def get_document_uid_by_path(path: str, repository) -> Union[str, None]:
 def get_document_by_ref(type_ref) -> DTO:
     # TODO: Get DataSource from Package's config file
     data_source_id, path = get_data_source_and_path(type_ref)
-    data_source = DataSource(data_source_id)
-    document_repository = get_repository(data_source)
+    document_repository = get_repository(data_source_id)
     type_id = get_document_uid_by_path(path, document_repository)
     if not type_id:
         raise EntityNotFoundException(uid=type_ref)

--- a/api/tests/core/service/test_document_service.py
+++ b/api/tests/core/service/test_document_service.py
@@ -74,8 +74,12 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         document_repository.get = mock_get
 
-        document_service = DocumentService(document_repository=document_repository, blueprint_provider=get_blueprint)
-        document_service.remove_document(document_id="1", parent_id=None)
+        def repository_provider(data_source_id):
+            if data_source_id == "testing":
+                return document_repository
+
+        document_service = DocumentService(repository_provider=repository_provider, blueprint_provider=get_blueprint)
+        document_service.remove_document(data_source_id="testing", document_id="1", parent_id=None)
         document_repository.delete.assert_called_with("1")
 
     def test_remove_nested(self):
@@ -96,8 +100,12 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         document_repository.get = mock_get
 
-        document_service = DocumentService(document_repository=document_repository, blueprint_provider=get_blueprint)
-        document_service.remove_document(document_id="1.nested", parent_id="1")
+        def repository_provider(data_source_id):
+            if data_source_id == "testing":
+                return document_repository
+
+        document_service = DocumentService(repository_provider=repository_provider, blueprint_provider=get_blueprint)
+        document_service.remove_document(data_source_id="testing", document_id="1.nested", parent_id="1")
         document_repository.update.assert_called_once()
 
     def test_remove_reference(self):
@@ -121,8 +129,12 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         document_repository.get = mock_get
 
-        document_service = DocumentService(document_repository=document_repository, blueprint_provider=get_blueprint)
-        document_service.remove_document(document_id="2", parent_id="1")
+        def repository_provider(data_source_id):
+            if data_source_id == "testing":
+                return document_repository
+
+        document_service = DocumentService(repository_provider=repository_provider, blueprint_provider=get_blueprint)
+        document_service.remove_document(data_source_id="testing", document_id="2", parent_id="1")
         document_repository.update.assert_called_once()
         document_repository.delete.assert_called_with("2")
 
@@ -144,8 +156,14 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         document_repository.get = mock_get
 
-        document_service = DocumentService(document_repository=document_repository, blueprint_provider=get_blueprint)
-        document = document_service.rename_attribute(parent_id="1", attribute="nested", name="New name")
+        def repository_provider(data_source_id):
+            if data_source_id == "testing":
+                return document_repository
+
+        document_service = DocumentService(repository_provider=repository_provider, blueprint_provider=get_blueprint)
+        document = document_service.rename_attribute(
+            data_source_id="testing", parent_id="1", attribute="nested", name="New name"
+        )
 
         assert isinstance(document.data, dict)
 

--- a/api/tests_bdd/steps/domain.py
+++ b/api/tests_bdd/steps/domain.py
@@ -1,11 +1,10 @@
 from anytree import NodeMixin, RenderTree
 from behave import given
-
-from classes.data_source import DataSource
-from classes.dto import DTO
 from core.enums import DMT, SIMOS
 from core.repository import Repository
 from core.repository.repository_factory import get_repository
+
+from classes.dto import DTO
 
 
 class TreeNode(NodeMixin):
@@ -48,12 +47,12 @@ def generate_tree_from_rows(node: TreeNode, rows):
 
 class Tree:
     def __init__(self, data_source_id, table):
-        self.data_source = DataSource(uid=data_source_id)
+        self.data_source_id = data_source_id
         self.table = table
         self.root = self._generate_tree()
 
     def add(self):
-        document_repository: Repository = get_repository(self.data_source)
+        document_repository: Repository = get_repository(self.data_source_id)
         for pre, fill, node in RenderTree(self.root):
             if node.type == SIMOS.BLUEPRINT.value:
                 document: DTO = DTO(
@@ -88,7 +87,7 @@ class Tree:
 
     def _generate_tree(self):
         # This node is used for prefixing everything with data source
-        root_node = TreeNode(uid=None, name=self.data_source.name, description="", type="", parent=None)
+        root_node = TreeNode(uid=None, name=self.data_source_id, description="", type="", parent=None)
         package = list(filter(lambda row: row["parent_uid"] == "", self.table.rows))[0]
         if not package:
             raise Exception("Root package is not found, you need to specify root package")

--- a/api/tests_bdd/steps/schemas.py
+++ b/api/tests_bdd/steps/schemas.py
@@ -1,13 +1,12 @@
 import json
 
 from behave import given
-
-from classes.data_source import DataSource
-from classes.dto import DTO
 from core.repository import Repository
 from core.repository.repository_factory import get_repository
-from config import Config
 from utils.package_import import import_package
+
+from classes.dto import DTO
+from config import Config
 
 
 @given("data modelling tool templates are imported")
@@ -18,7 +17,6 @@ def step_impl(context):
 
 @given('there exist document with id "{uid}" in data source "{data_source_id}"')
 def step_impl_2(context, uid: str, data_source_id: str):
-    data_source = DataSource(uid=data_source_id)
     document: DTO = DTO(uid=uid, data=json.loads(context.text))
-    document_repository: Repository = get_repository(data_source)
+    document_repository: Repository = get_repository(data_source_id)
     document_repository.add(document)


### PR DESCRIPTION
## What does this pull request change?

* Move document repository to the constructor to avoid have it as input to all methods
* Use repository provider inside document service to allow multiple data sources

## Why is this pull request needed?

## Issues related to this change:
