### PR TITLE
service layer save func

### DIFF
--- a/api/classes/dto.py
+++ b/api/classes/dto.py
@@ -1,5 +1,5 @@
 from typing import Dict, Optional
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 
 # For backwards compatibility, data is not a private property.
@@ -22,7 +22,7 @@ class DTO:
         self.data = data
 
     def get(self, key, default=None):
-        if default:
+        if default is not None:
             return self.data.get(key, default)
         return self.data.get(key)
 

--- a/api/classes/storage_recipe.py
+++ b/api/classes/storage_recipe.py
@@ -25,7 +25,7 @@ class StorageRecipe:
             for attribute in attributes
         }
 
-    def is_contained(self, attribute_name, attribute_type):
+    def is_contained(self, attribute_name, attribute_type=None):
         if attribute_name in self.storage_attributes:
             return self.storage_attributes[attribute_name].is_contained
         if attribute_type in PRIMITIVES:

--- a/api/tests/core/service/test_document_service.py
+++ b/api/tests/core/service/test_document_service.py
@@ -1,12 +1,13 @@
 import unittest
 from unittest import mock
 
-from classes.blueprint import Blueprint
-
-from classes.dto import DTO
 from core.repository import Repository
-from core.service.document_service import get_complete_document, DocumentService
+from core.service.document_service import DocumentService, get_complete_document
 from utils.data_structure.compare import pretty_eq
+
+from classes.blueprint import Blueprint
+from classes.dto import DTO
+from classes.tree_node import Node
 
 blueprint_1 = {
     "type": "system/SIMOS/Blueprint",
@@ -171,8 +172,165 @@ class DocumentServiceTestCase(unittest.TestCase):
 
         assert pretty_eq(actual, document.data) is None
 
-    def test_get_complete_document(self):
+    def test_save_update(self):
+        repository: Repository = mock.Mock()
 
+        doc_storage = {
+            "1": {
+                "uid": "1",
+                "name": "Parent",
+                "description": "",
+                "type": "blueprint_1",
+                "nested": {"name": "Nested", "description": "", "type": "blueprint_2"},
+                "reference": {"_id": "2", "name": "a_reference", "type": "blueprint_2"},
+                "references": [
+                    {"_id": "3", "name": "ref1", "type": "blueprint_2"},
+                    {"_id": "4", "name": "ref2", "type": "blueprint_2"},
+                ],
+            },
+            "2": {"uid": "2", "_id": "2", "name": "a_reference", "description": "", "type": "blueprint_2"},
+            "3": {"uid": "3", "_id": "3", "name": "ref1", "description": "", "type": "blueprint_2"},
+            "4": {"uid": "4", "_id": "4", "name": "ref2", "description": "TEST", "type": "blueprint_2"},
+        }
+
+        doc_1_after = {
+            "_id": "1",
+            "name": "Parent",
+            "description": "",
+            "type": "blueprint_1",
+            "nested": {"name": "Nested", "description": "", "type": "blueprint_2"},
+            "reference": {"_id": "2", "name": "a_reference", "type": "blueprint_2"},
+            "references": [
+                {"_id": "3", "name": "ref1", "type": "blueprint_2"},
+                {"_id": "4", "name": "ref2", "type": "blueprint_2"},
+            ],
+        }
+
+        doc_4_after = {"_id": "4", "name": "ref2", "description": "TEST_MODIFY", "type": "blueprint_2"}
+
+        def mock_get(document_id: str):
+            return DTO(doc_storage[document_id])
+
+        def mock_update(dto: DTO):
+            doc_storage[dto.uid] = dto.data
+            return None
+
+        def repository_provider(data_source_id):
+            if data_source_id == "testing":
+                return repository
+
+        repository.get = mock_get
+        repository.update = mock_update
+        document_service = DocumentService(blueprint_provider=get_blueprint, repository_provider=repository_provider)
+
+        node: Node = document_service.get_by_uid("testing", "1")
+        contained_node: Node = node.search("4")
+        contained_node.update({"description": "TEST_MODIFY"})
+        document_service.save(node, "testing")
+
+        assert doc_1_after == doc_storage["1"]
+        assert doc_4_after == doc_storage["4"]
+
+    def test_save_append(self):
+        repository: Repository = mock.Mock()
+
+        doc_storage = {
+            "1": {"uid": "1", "name": "Parent", "description": "", "type": "blueprint_1", "references": []},
+            "2": {"uid": "2", "_id": "2", "name": "a_reference", "description": "", "type": "blueprint_2"},
+        }
+
+        document_1_after = {
+            "_id": "1",
+            "name": "Parent",
+            "description": "",
+            "type": "blueprint_1",
+            "nested": {},
+            "reference": {},
+            "references": [{"name": "a_reference", "type": "blueprint_2", "_id": "2"}],
+        }
+
+        def mock_get(document_id: str):
+            return DTO(doc_storage[document_id])
+
+        def mock_update(dto: DTO):
+            doc_storage[dto.uid] = dto.data
+            return None
+
+        repository.get = mock_get
+        repository.update = mock_update
+
+        def repository_provider(data_source_id):
+            if data_source_id == "testing":
+                return repository
+
+        document_service = DocumentService(blueprint_provider=get_blueprint, repository_provider=repository_provider)
+
+        node: Node = document_service.get_by_uid("testing", "1")
+        contained_node: Node = node.search("1.references")
+        contained_node.children.append(Node("0", DTO(doc_storage["2"]), contained_node.blueprint))
+        document_service.save(node, "testing")
+
+        assert document_1_after == doc_storage["1"]
+
+    def test_save_delete(self):
+        repository: Repository = mock.Mock()
+
+        doc_storage = {
+            "1": {
+                "_id": "1",
+                "uid": "1",
+                "name": "Parent",
+                "description": "",
+                "type": "blueprint_1",
+                "references": [
+                    {"_id": "2", "name": "a_reference", "type": "blueprint_2"},
+                    {"_id": "3", "name": "a_reference", "type": "blueprint_2"},
+                    {"_id": "4", "name": "a_reference", "type": "blueprint_2"},
+                ],
+            },
+            "2": {"uid": "2", "_id": "2", "name": "a_reference", "description": "Index 1", "type": "blueprint_2"},
+            "3": {"uid": "3", "_id": "3", "name": "a_reference", "description": "Index 2", "type": "blueprint_2"},
+            "4": {"uid": "4", "_id": "4", "name": "a_reference", "description": "Index 3", "type": "blueprint_2"},
+        }
+
+        doc_1_after = {
+            "name": "Parent",
+            "_id": "1",
+            "description": "",
+            "type": "blueprint_1",
+            "nested": {},
+            "reference": {},
+            "references": [
+                {"_id": "2", "name": "a_reference", "type": "blueprint_2"},
+                {"_id": "4", "name": "a_reference", "type": "blueprint_2"},
+            ],
+        }
+
+        def mock_get(document_id: str):
+            return DTO(doc_storage[document_id])
+
+        def mock_update(dto: DTO):
+            doc_storage[dto.uid] = dto.data
+            return None
+
+        repository.get = mock_get
+        repository.update = mock_update
+
+        def repository_provider(data_source_id):
+            if data_source_id == "testing":
+                return repository
+
+        document_service = DocumentService(blueprint_provider=get_blueprint, repository_provider=repository_provider)
+
+        node: Node = document_service.get_by_uid("testing", "1")
+        contained_node: Node = node.search("1.references")
+        contained_node.remove_by_path(["1"])
+        document_service.save(node, "testing")
+
+        assert doc_1_after == doc_storage["1"]
+        assert doc_storage["3"] is not None
+
+    def test_get_complete_document(self):
         document_1 = {
             "uid": "1",
             "name": "Parent",

--- a/api/tests_bdd/explorer/remove.feature
+++ b/api/tests_bdd/explorer/remove.feature
@@ -70,16 +70,8 @@ Feature: Explorer - Remove
     Then the response status should be "OK"
     Given I access the resource url "/api/v2/documents/data-source-name/1"
     When I make a "GET" request
-    Then the response at document.content should equal
-    """
-    [
-      {
-        "name": "sub_package_2",
-        "_id": "4",
-        "type" : "system/DMT/Package"
-      }
-    ]
-    """
+    Then the array at document.content should be of length 1
+
     Given I access the resource url "/api/v2/documents/data-source-name/2"
     When I make a "GET" request
     Then the response status should be "System Error"


### PR DESCRIPTION
## What does this pull request change?
* Adds a save(Node) func in document_service.
 This saves the modified NodeTree to datasource, considering storage_contained
* Added UnitTests

## Why is this pull request needed?

Simplify operations on documents and the Node Tree Datastructure

