### PR TITLE
add and use blueprintsPicker widget

### DIFF
--- a/api/home/core/SIMOS/Application.json
+++ b/api/home/core/SIMOS/Application.json
@@ -84,7 +84,7 @@
         {
           "name": "models",
           "type": "system/SIMOS/UiAttribute",
-          "field": "packages"
+          "field": "blueprints"
         }
       ]
     }

--- a/web/src/plugins/form-rjsf-widgets/MultiSelectorWidget.tsx
+++ b/web/src/plugins/form-rjsf-widgets/MultiSelectorWidget.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 import DocumentTree from '../../pages/common/tree-view/DocumentTree'
 import Modal from '../../components/modal/Modal'
 import { FaTimes } from 'react-icons/fa'
+import { BlueprintEnum } from '../../util/variables'
 
 const api = new DmtApi()
 
@@ -42,13 +43,19 @@ const BlueButton = styled.button`
   border-radius: 4px;
 `
 
-type PackageSelectorProps = {
+type MultiSelectorProps = {
   onChange: Function
   formData: any
   uiSchema: any
+  typeFilter: Function
 }
 
-export default ({ onChange, formData, uiSchema }: PackageSelectorProps) => {
+const MultiSelector = ({
+  onChange,
+  formData,
+  uiSchema,
+  typeFilter,
+}: MultiSelectorProps) => {
   const [datasources, setDatasources] = useState<Datasource[]>([])
   const [selectedPackages, setSelectedPackages] = useState<string[]>(formData)
   const [showModal, setShowModal] = useState<boolean>(false)
@@ -142,7 +149,7 @@ export default ({ onChange, formData, uiSchema }: PackageSelectorProps) => {
             return (
               <NodeWrapper>
                 {nodeData.title}
-                {nodeData.meta.isRootPackage && (
+                {typeFilter(nodeData) && (
                   <input
                     type={'checkbox'}
                     checked={selectedPackages.includes(value) || false}
@@ -159,4 +166,28 @@ export default ({ onChange, formData, uiSchema }: PackageSelectorProps) => {
       </Modal>
     </PackagesWrapper>
   )
+}
+
+export const PackagesSelector = ({ onChange, formData, uiSchema }: any) => {
+  function PackageFilter(nodeData: any) {
+    return nodeData.meta?.isRootPackage
+  }
+  return MultiSelector({
+    onChange,
+    formData,
+    uiSchema,
+    typeFilter: PackageFilter,
+  })
+}
+
+export const BlueprintsSelector = ({ onChange, formData, uiSchema }: any) => {
+  function BlueprintsFilter(nodeData: any) {
+    return nodeData?.meta?.type == BlueprintEnum.BLUEPRINT
+  }
+  return MultiSelector({
+    onChange,
+    formData,
+    uiSchema,
+    typeFilter: BlueprintsFilter,
+  })
 }

--- a/web/src/plugins/form_rjsf_edit/EditForm.tsx
+++ b/web/src/plugins/form_rjsf_edit/EditForm.tsx
@@ -8,7 +8,10 @@ import { BlueprintProvider } from '../BlueprintProvider'
 import FileDirectoryWidget from '../form-rjsf-widgets/FileDirectoryWidget'
 import DestinationSelectorWidget from '../form-rjsf-widgets/DestinationSelectorWidget'
 import { CollapsibleField } from '../widgets/CollapsibleField'
-import PackageSelectorWidget from '../form-rjsf-widgets/PackagesSelectorWidget'
+import {
+  PackagesSelector,
+  BlueprintsSelector,
+} from '../form-rjsf-widgets/MultiSelectorWidget'
 import BlueprintSelectorWidget from '../form-rjsf-widgets/BlueprintSelectorWidget'
 
 export interface EditPluginProps extends PluginProps {
@@ -36,7 +39,8 @@ export const EditPlugin = (props: EditPluginProps) => {
           collapsible: CollapsibleField,
           destination: DestinationSelectorWidget,
           blueprint: BlueprintSelectorWidget,
-          packages: PackageSelectorWidget,
+          blueprints: BlueprintsSelector,
+          packages: PackagesSelector,
           hidden: () => <div />,
         }}
         widgets={{


### PR DESCRIPTION
## What does this pull request change?
Wraps the MultiSelector to take a filter Funtion so it can be used to different types.

## Why is this pull request needed?
* We sometimes need to select multiple documents of other types than Packages
## Issues related to this change:
closes #579 
