### PR TITLE
match indent of expandable nodes, for none expandable nodes

### DIFF
--- a/web/src/components/tree-view/TreeNode.tsx
+++ b/web/src/components/tree-view/TreeNode.tsx
@@ -81,6 +81,11 @@ export type TreeNodeRenderProps = {
 const Content = styled.div`
   width: 100%;
 `
+
+const ArrowPlaceholderIndent = styled.div`
+  width: 12px;
+  height: 18px;
+`
 type Props = {
   node: TreeNodeData
 }
@@ -146,6 +151,7 @@ const TreeNode = (props: TreeNodeProps) => {
           <NodeIcon>
             {node.isExpandable && node.isOpen && <FaChevronDown />}
             {node.isExpandable && !node.isOpen && <FaChevronRight />}
+            {!node.isExpandable && <ArrowPlaceholderIndent />}
           </NodeIcon>
           <NodeIcon marginRight={5}>
             <GetIcon node={node} />


### PR DESCRIPTION
# What does this pull request change?
* Adds a empty div element in front of none-expandable nodes
## Why is this pull request needed?
* All nodes on the same tree level should have matching indentation
## Issues related to this change:
closes #496 