### PR TITLE
feat: May verify blueprints, and entities on import (may be disabled)

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -41,7 +41,10 @@ def init_application():
     logger.info(f"Importing entity package(s) {Config.ENTITY_APPLICATION_SETTINGS['entities']}")
     for folder in Config.ENTITY_APPLICATION_SETTINGS["entities"]:
         import_package(
-            f"{Config.APPLICATION_HOME}/entities/{folder}", collection=Config.ENTITY_COLLECTION, is_root=True
+            f"{Config.APPLICATION_HOME}/entities/{folder}",
+            collection=Config.ENTITY_COLLECTION,
+            is_root=True,
+            is_entity=True,
         )
 
 

--- a/api/config.py
+++ b/api/config.py
@@ -21,6 +21,7 @@ class Config:
     DMT_SETTINGS_FILE = f"{APPLICATION_HOME}/dmt_settings.json"
     ENTITY_SETTINGS_FILE = f"{APPLICATION_HOME}/settings.json"
     SYSTEM_FOLDERS = ["SIMOS", "DMT"]
+    VERIFY_IMPORTS = os.getenv("DMT_VERIFY_IMPORTS", True)
     with open(DMT_SETTINGS_FILE) as json_file:
         DMT_APPLICATION_SETTINGS = json.load(json_file)
     with open(ENTITY_SETTINGS_FILE) as json_file:

--- a/api/home/blueprints/CarPackage/Car.json
+++ b/api/home/blueprints/CarPackage/Car.json
@@ -22,6 +22,7 @@
       "attributeType": "string",
       "type": "system/SIMOS/BlueprintAttribute",
       "name": "manufacturer",
+      "optional": true,
       "default": ""
     },
     {

--- a/api/home/blueprints/TodoDemo/Todo.json
+++ b/api/home/blueprints/TodoDemo/Todo.json
@@ -21,7 +21,7 @@
     {
       "attributeType": "integer",
       "type": "system/SIMOS/BlueprintAttribute",
-      "name": "id"
+      "name": "todo_id"
     },
     {
       "attributeType": "integer",

--- a/api/home/entities/TodoDemo/Todo.json
+++ b/api/home/entities/TodoDemo/Todo.json
@@ -1,9 +1,14 @@
 {
   "type": "SSR-DataSource/TodoDemo/Todo",
   "name": "Todo",
+  "description": "Used for demonstration",
+  "todo_id": 1,
+  "user_id": 20,
+  "completed": false,
   "list": {
      "name": "List",
      "type": "SSR-DataSource/TodoDemo/TodoList",
+     "description": "",
      "items": []
   }
 }

--- a/api/home/entities/TodoDemo/TodoList.json
+++ b/api/home/entities/TodoDemo/TodoList.json
@@ -1,5 +1,6 @@
 {
   "type": "SSR-DataSource/TodoDemo/TodoList",
   "name": "TodoList",
+  "description": "An example of a list of todos",
   "items": []
 }

--- a/api/tests_bdd/code_generation/schema.feature
+++ b/api/tests_bdd/code_generation/schema.feature
@@ -1,0 +1,6 @@
+Feature: Class generation from schema
+
+  Scenario: There, and back again
+    Given data modelling tool templates are imported
+    When I create a Python class from the template "system/SIMOS/Blueprint"
+    Then it should be able to recreate the template

--- a/api/tests_bdd/steps/schemas.py
+++ b/api/tests_bdd/steps/schemas.py
@@ -1,8 +1,13 @@
 import json
 
-from behave import given
+from behave import given, when, then
+
+from classes.schema import Factory
 from core.repository import Repository
+from core.repository.file import TemplateRepositoryFromFile
 from core.repository.repository_factory import get_repository
+from utils.data_structure.compare import pretty_eq
+from utils.helper_functions import schemas_location
 from utils.logging import logger
 from utils.package_import import import_package
 
@@ -23,3 +28,18 @@ def step_impl_2(context, uid: str, data_source_id: str):
     document: DTO = DTO(uid=uid, data=json.loads(context.text))
     document_repository: Repository = get_repository(data_source_id)
     document_repository.add(document)
+
+
+@when('I create a Python class from the template "{template_name}"')
+def step_impl_create_template(context, template_name: str):
+    document_repository = TemplateRepositoryFromFile(schemas_location())
+    factory = Factory(document_repository, read_from_file=True)
+    context.template_name = template_name
+    context.template = factory.create(template_name)
+
+
+@then("it should be able to recreate the template")
+def step_impl_compare(context):
+    expected = TemplateRepositoryFromFile(schemas_location()).get(context.template_name)
+    actual = context.template.to_dict()
+    pretty_eq(expected, actual)

--- a/api/utils/package_import.py
+++ b/api/utils/package_import.py
@@ -3,17 +3,49 @@ import os
 from typing import Dict, List, Union
 
 from classes.dto import DTO
+from config import Config
 from core.enums import DMT, SIMOS
+
+from classes.schema import Factory
+from core.repository.file import TemplateRepositoryFromFile
 from services.database import dmt_database as dmt_db
 from utils.logging import logger
 
+from utils.helper_functions import schemas_location
 
-def _add_documents(path, documents, collection) -> List[Dict]:
+
+def get_template_type(directory: str, file: str) -> str:
+    path = f"{directory}/{file}"
+    if path.endswith(".json"):
+        path = path[: -len(".json")]
+    if "/core/" in path:
+        path = replace_prefix(path, "system", "core")
+    elif "/blueprints/" in path:
+        path = replace_prefix(path, "SSR-DataSource", "blueprints")
+    else:
+        raise ValueError
+    return path
+
+
+def replace_prefix(path, prefix, where):
+    index = path.find(f"/{where}/")
+    return f"{prefix}/{path[index + len(f'/{where}/'):]}"
+
+
+def _add_documents(path, documents, collection, is_entity=False) -> List[Dict]:
     docs = []
     for file in documents:
         logger.info(f"Working on {file}...")
         with open(f"{path}/{file}") as json_file:
             data = json.load(json_file)
+        if Config.VERIFY_IMPORTS:
+            template_repository = TemplateRepositoryFromFile(schemas_location())
+            factory = Factory(template_repository, read_from_file=True)
+            if is_entity:
+                Blueprint = factory.create(data["type"])
+                instance = Blueprint.from_dict(data)
+            else:
+                Blueprint = factory.create(get_template_type(path, file))
         if data["type"] == SIMOS.BLUEPRINT.value:
             document = DTO(data)
         else:
@@ -23,7 +55,7 @@ def _add_documents(path, documents, collection) -> List[Dict]:
     return docs
 
 
-def import_package(path, collection: str, is_root: bool = False) -> Union[Dict]:
+def import_package(path, collection: str, is_root: bool = False, is_entity=False) -> Union[Dict]:
     # TODO: Package class
     package = {"name": os.path.basename(path), "type": DMT.PACKAGE.value, "isRoot": is_root}
     files = []
@@ -33,7 +65,7 @@ def import_package(path, collection: str, is_root: bool = False) -> Union[Dict]:
         files.extend(file)
         break
 
-    package["content"] = _add_documents(path, documents=files, collection=collection)
+    package["content"] = _add_documents(path, documents=files, collection=collection, is_entity=is_entity)
     for folder in directories:
         package["content"].append(import_package(f"{path}/{folder}", is_root=False, collection=collection))
 


### PR DESCRIPTION
## What does this pull request change?
Enables verification of blueprints, and entities when they are imported to DMT.

This behaviour may be disabled, by setting the environment variable `DMT_VERIFY_IMPORTS` to `False`

## Why is this pull request needed?
Ensure consistency of blueprints, and entities.

## Issues related to this change:
