### PR TITLE
add support for update in external plugins

### DIFF
--- a/web/src/external-plugins/index.js
+++ b/web/src/external-plugins/index.js
@@ -22,7 +22,8 @@ export default function pluginHook(uiRecipe) {
   return registeredPlugins[uiRecipe.name]
 }
 
-function PlotlyPoc() {
+function PlotlyPoc(props) {
+  const { updateEntity, document } = props
   return (
     <Plot
       data={[
@@ -35,6 +36,10 @@ function PlotlyPoc() {
         },
         { type: 'bar', x: [1, 2, 3], y: [2, 5, 3] },
       ]}
+      onClick={() => {
+        document.description = 'test update'
+        updateEntity(document)
+      }}
       layout={{ width: 320, height: 240, title: 'A Fancy Plot' }}
     />
   )

--- a/web/src/pages/common/layout-components/DocumentComponent.tsx
+++ b/web/src/pages/common/layout-components/DocumentComponent.tsx
@@ -104,13 +104,33 @@ const View = (props: any) => {
     case RegisteredPlugins.TABLE:
       return <ReactTablePlugin {...pluginProps} />
     case RegisteredPlugins.EXTERNAL:
-      const ExternalPlugin = pluginHook(uiRecipe)
-      if (ExternalPlugin) {
-        return <ExternalPlugin {...props} />
-      }
+      return (
+        <LayoutContext.Consumer>
+          {(layout: any) => {
+            // wrap onFormSubmit to hide the rjsf specific schemas input.
+            // first invoke onFormSubmit witch returns a function with param schemas.
+            const onFormSubmitWrapper: Function = onFormSubmit({
+              attribute: null,
+              dataUrl,
+              layout,
+            })
+            // create a new function with param formData instead of schemas.
+            const updateEntity = (formData: any) => {
+              console.log(formData)
+              onFormSubmitWrapper({ formData })
+            }
+            // pass the wrapper function updateEntity to the plugins.
+            const ExternalPlugin = pluginHook(uiRecipe)
+            if (ExternalPlugin) {
+              return <ExternalPlugin {...props} updateEntity={updateEntity} />
+            }
+          }}
+        </LayoutContext.Consumer>
+      )
       break
+    default:
+      console.warn(`Plugin not supported: ${uiRecipe.plugin}`)
   }
-  console.warn(`Plugin not supported: ${uiRecipe.plugin}`)
   return <div>{`Plugin not supported: ${uiRecipe.plugin}`}</div>
 }
 


### PR DESCRIPTION
##  What does this pull request change?
add update to external plugins

## Why is this pull request needed?
plugins should have access to update entities
supports updating standalone entities, like editplugin. 

## Issues related to this change:
#574 

Test update functionality:
go to plotly view, click on the chart.

TODO: add validation on api side, Node.validate #580 