### PR TITLE
Add optional context menu

### DIFF
--- a/api/classes/tree_node.py
+++ b/api/classes/tree_node.py
@@ -197,6 +197,9 @@ class NodeBase:
     def has_uid(self):
         return self.uid != ""
 
+    def is_empty(self):
+        return not self.entity
+
     @property
     def parent_node_id(self):
         if not self.parent:

--- a/api/core/repository/mongo/__init__.py
+++ b/api/core/repository/mongo/__init__.py
@@ -34,7 +34,8 @@ class MongoDBClient(DBClientInterface):
 
     def update(self, uid: str, document: Dict) -> bool:
         try:
-            return self.handler[self.collection].update_one({"_id": uid}, {"$set": document}, upsert=True).acknowledged
+            # Update replaces the entire document in the database with the posted document
+            return self.handler[self.collection].replace_one({"_id": uid}, document, upsert=True).acknowledged
         except Exception as error:
             print("ERROR", error)
             return False

--- a/api/core/use_case/generate_index_use_case.py
+++ b/api/core/use_case/generate_index_use_case.py
@@ -64,13 +64,12 @@ def get_node(node: Union[Node], data_source_id: str, app_settings: dict) -> Dict
         "type": node.type,
         "meta": {
             "menuItems": menu_items,
-            "onSelect": get_node_on_select(data_source_id, node)
-            if node.is_single() and node.type != DMT.PACKAGE.value and node.type != "datasource"
-            else {},
+            "onSelect": get_node_on_select(data_source_id, node),
             "error": False,
             "isRootPackage": node.type == DMT.PACKAGE.value and node.entity.get("isRoot"),
             "isList": node.is_array(),
             "dataSource": data_source_id,
+            "empty": node.is_empty(),
         },
     }
 
@@ -78,11 +77,10 @@ def get_node(node: Union[Node], data_source_id: str, app_settings: dict) -> Dict
 def is_visible(node):
     if node.is_root():
         return True
-    elif not node.entity and not node.is_array():
-        return False
     elif node.is_complex_array():
         return False
-
+    elif node.is_empty():
+        return False
     if node.parent.blueprint is None:
         return True
 

--- a/api/core/use_case/utils/generate_index_menu_actions.py
+++ b/api/core/use_case/utils/generate_index_menu_actions.py
@@ -43,10 +43,10 @@ def get_delete_menu_item(
     }
 
 
-def get_dynamic_create_menu_item(data_source_id: str, name: str, type: str, node_id: str = None):
+def get_dynamic_create_menu_item(data_source_id: str, name: str, type: str, node_id: str = None, label: str = None):
     node_id_split = node_id.split(".", 1)
     return {
-        "label": f"{name}",
+        "label": label if label else name,
         "action": "CREATE",
         "data": {
             "url": f"/api/v2/explorer/{data_source_id}/add-file",
@@ -112,6 +112,10 @@ def get_download_menu_action(data_source_id: str, document_id: str):
 
 
 def get_node_on_select(data_source_id: str, tree_node: Union[Node]):
+    if tree_node.type in ["datasource", DMT.PACKAGE.value]:
+        return None
+    if tree_node.is_empty():
+        return None
     split_node_id_attribute = tree_node.node_id.split(".", 1)
     attribute = f"?attribute={split_node_id_attribute[-1]}" if len(split_node_id_attribute) > 1 else ""
     return {

--- a/api/core/use_case/utils/set_index_context_menu.py
+++ b/api/core/use_case/utils/set_index_context_menu.py
@@ -1,8 +1,8 @@
-from typing import Union
-
 from classes.tree_node import Node
 from core.enums import DMT, SIMOS
 from core.use_case.utils.generate_index_menu_actions import (
+    get_create_reference_menu_item,
+    get_create_root_package_menu_item,
     get_delete_menu_item,
     get_download_menu_action,
     get_dynamic_create_menu_item,
@@ -10,19 +10,27 @@ from core.use_case.utils.generate_index_menu_actions import (
     get_import_menu_item,
     get_rename_menu_action,
     get_runnable_menu_action,
-    get_create_root_package_menu_item,
-    get_create_reference_menu_item,
 )
-from core.utility import BlueprintProvider
-from utils.group_by import group_by
-
 from core.use_case.utils.sort_menu_items import sort_menu_items
+from utils.group_by import group_by
 
 
 def create_context_menu(node: Node, data_source_id: str, app_settings: dict):
     menu_items = []
     create_new_menu_items = []
     is_package = node.type == DMT.PACKAGE.value
+
+    # Add create entry for optional attributes
+    for empty_child in [child for child in node.children if child.is_empty()]:
+        create_new_menu_items.append(
+            get_dynamic_create_menu_item(
+                data_source_id=data_source_id,
+                name=empty_child.name,
+                type=empty_child.type,
+                node_id=empty_child.node_id,
+                label=f"Create {empty_child.name}",
+            )
+        )
 
     # Datasource Node can only add root-packages
     if node.type == "datasource":
@@ -45,6 +53,17 @@ def create_context_menu(node: Node, data_source_id: str, app_settings: dict):
                     )
                 )
         else:
+            # Add create entry for optional attributes (not for packages)
+            for empty_child in [child for child in node.children if child.is_empty()]:
+                create_new_menu_items.append(
+                    get_dynamic_create_menu_item(
+                        data_source_id=data_source_id,
+                        name=empty_child.name,
+                        type=empty_child.type,
+                        node_id=empty_child.node_id,
+                        label=f"Create {empty_child.name}",
+                    )
+                )
             if node.is_array():
                 # List nodes can always append entities of it's own type
                 create_new_menu_items.append(

--- a/api/coverage.txt
+++ b/api/coverage.txt
@@ -9,7 +9,7 @@ core/repository/__init__.py                                   34     22    35.3%
 utils/helper_functions.py                                     15      9    40.0%   6-9, 13-17
 tests/core/domain/test_package.py                             24     14    41.7%   8-12, 17-19, 24-26, 31-34
 utils/data_structure/compare.py                               28     16    42.9%   9-10, 18-23, 25-32
-core/repository/mongo/__init__.py                             30     17    43.3%   13-22, 25-26, 29-33, 36-40, 43, 46, 49
+core/repository/mongo/__init__.py                             30     17    43.3%   13-22, 25-26, 29-33, 36-41, 44, 47, 50
 tests/classes/test_tree_error_node.py                         15      7    53.3%   29-45
 classes/recipe.py                                             39     18    53.8%   21, 38-57, 60, 68
 utils/data_structure/find.py                                  37     16    56.8%   23-24, 28-30, 34-45
@@ -24,7 +24,7 @@ core/repository/file/__init__.py                              32      8    75.0%
 utils/data_structure/traverse.py                              35      8    77.1%   20, 53-55, 59-62
 tests/core/repository/mongo/test_document_repository.py        9      2    77.8%   12-13
 utils/get_data_type.py                                         9      2    77.8%   11-12
-classes/tree_node.py                                         310     64    79.4%   102-108, 132-134, 175-176, 182, 194-195, 202-205, 251, 254-256, 262, 265, 274-277, 292, 298, 311-344, 363, 371, 385, 395, 447-448, 462-463, 473-474, 490-496, 518, 526
+classes/tree_node.py                                         312     65    79.2%   102-108, 132-134, 175-176, 182, 194-195, 201, 205-208, 254, 257-259, 265, 268, 277-280, 295, 301, 314-347, 366, 374, 388, 398, 450-451, 465-466, 476-477, 493-499, 521, 529
 core/shared/request_object.py                                 17      3    82.4%   6, 12, 20
 core/service/document_service.py                             149     23    84.6%   17, 28, 50, 54-57, 71-72, 104, 107, 127-132, 139, 148, 153, 168, 193, 205, 211, 225, 231
 classes/dimension.py                                          38      5    86.8%   16, 20, 38, 53, 58
@@ -35,11 +35,11 @@ core/enums.py                                                 43      4    90.7%
 classes/blueprint_attribute.py                                33      3    90.9%   36, 47, 61
 tests/utils/test_create_default_array.py                      47      4    91.5%   95, 97, 99, 157
 utils/group_by.py                                             17      1    94.1%   18
-tests/core/document_service/test_remove.py                    79      4    94.9%   23, 55, 94, 125
+tests/core/document_service/test_remove.py                    93      4    95.7%   20, 52, 91, 122
 tests/core/document_service/test_get.py                       32      1    96.9%   44
 tests/core/document_service/test_rename.py                    83      2    97.6%   31, 70
 tests/classes/test_tree_node.py                              182      1    99.5%   119
 ------------------------------------------------------------------------------------------
-TOTAL                                                       2390    499    79.1%
+TOTAL                                                       2406    500    79.2%
 
 28 files skipped due to complete coverage.

--- a/api/home/blueprints/CarPackage/Parking.json
+++ b/api/home/blueprints/CarPackage/Parking.json
@@ -24,6 +24,13 @@
       "name": "cars",
       "optional": true,
       "dimensions": "*"
+    },
+    {
+      "attributeType": "SSR-DataSource/CarPackage/Wheel",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "name": "wheels",
+      "dimensions": "",
+      "optional": true
     }
   ],
   "storageRecipes": [],

--- a/web/src/components/tree-view/Tree.tsx
+++ b/web/src/components/tree-view/Tree.tsx
@@ -26,6 +26,7 @@ export enum NodeIconType {
 export type NodeMetaData = {
   [key: string]: any
   isRootPackage?: boolean
+  empty?: boolean
   isList?: boolean
   error?: boolean
   dataSource?: string

--- a/web/src/components/tree-view/TreeNode.tsx
+++ b/web/src/components/tree-view/TreeNode.tsx
@@ -93,6 +93,7 @@ type Props = {
 const GetIcon = ({ node }: Props) => {
   if (node.meta.error)
     return <FaExclamationTriangle style={{ color: 'orange' }} />
+  if (node.meta.empty) return <b>{'{}'}</b>
 
   switch (node.icon) {
     case NodeIconType.database:

--- a/web/src/pages/common/tree-view/TreeNodeBuilderOld.ts
+++ b/web/src/pages/common/tree-view/TreeNodeBuilderOld.ts
@@ -10,6 +10,7 @@ type IndexNodeV2 = {
   id: string
   filename: string
   isRootPackage?: boolean
+  empty?: boolean
   nodeType: NodeType
   children?: string[]
   templateRef?: string
@@ -62,17 +63,17 @@ function createTreeNode({
     templateRef,
     nodeType,
     meta: { ...meta, type },
-    isExpandable: isExpandable(type, children),
+    isExpandable: isExpandable(type, children, meta),
     isOpen: false,
     isRoot: type === NodeType.DATA_SOURCE,
     isHidden: false,
     children: children || [],
-    icon: getNodeIcon(type, children),
+    icon: getNodeIcon(type),
     isFolder: true,
   }
 }
 
-function getNodeIcon(nodeType: string, children: string[]): NodeIconType {
+function getNodeIcon(nodeType: string): NodeIconType {
   switch (nodeType) {
     case NodeType.PACKAGE:
       return NodeIconType.folder
@@ -89,7 +90,12 @@ function getNodeIcon(nodeType: string, children: string[]): NodeIconType {
   }
 }
 
-function isExpandable(nodeType: string, children: string[]): boolean {
+function isExpandable(
+  nodeType: string,
+  children: string[],
+  meta: any
+): boolean {
+  if (meta.empty) return false
   if (nodeType === NodeType.PACKAGE) {
     return true
   } else {


### PR DESCRIPTION
## What does this pull request change?
* Adds context-menu for optional entities
* MongoRepository.update() uses replace_one instead of update_one()


## Why is this pull request needed?
Working with optional attributes is a requirement

## Issues related to this change:
closes #562 
closes #580