### PR TITLE
bug: child entity name from attribute name

### DIFF
--- a/api/core/use_case/utils/create_entity.py
+++ b/api/core/use_case/utils/create_entity.py
@@ -30,8 +30,8 @@ class CreateEntity:
         self.attribute_types = self.blueprint_provider.get_blueprint(SIMOS.ATTRIBUTE_TYPES.value).to_dict()
         self.blueprint_attribute: Blueprint = self.blueprint_provider.get_blueprint(SIMOS.BLUEPRINT_ATTRIBUTE.value)
         blueprint: Blueprint = self.blueprint_provider.get_blueprint(type)
-        entity = {"name": name, "description": description}
-        self._entity = self._get_entity(blueprint=blueprint, parent_type=type, entity=entity)
+        entity = {"name": name, "description": description, "type": type}
+        self._entity = self._get_entity(blueprint=blueprint, entity=entity)
 
     @staticmethod
     def parse_value(attr: BlueprintAttribute, blueprint_provider):
@@ -65,31 +65,17 @@ class CreateEntity:
             return int(default_value)
         return default_value
 
-    @staticmethod
-    def default_value(attr: BlueprintAttribute, parent_type: str, blueprint_provider):
-        if attr.name == "type":
-            return parent_type
-        return CreateEntity.parse_value(attr=attr, blueprint_provider=blueprint_provider)
-
     @property
     def entity(self):
         return self._entity
 
     # add all non optional attributes with default value.
     # type is inserted based on the parent attributes type, or the initial type for root entity.
-    def _get_entity(self, blueprint: Blueprint, parent_type: str, entity):
+    def _get_entity(self, blueprint: Blueprint, entity):
         for attr in blueprint.attributes:
             if attr.attribute_type in PRIMITIVES:
-                if not attr.is_optional():
-                    default_value = CreateEntity.default_value(
-                        attr=attr, parent_type=parent_type, blueprint_provider=self.blueprint_provider
-                    )
-
-                    if attr.name == "name" and len(default_value) == 0:
-                        default_value = parent_type.split("/")[-1].lower()
-
-                    if attr.name not in entity:
-                        entity[attr.name] = default_value
+                if not attr.is_optional() and attr.name not in entity:
+                    entity[attr.name] = CreateEntity.parse_value(attr=attr, blueprint_provider=self.blueprint_provider)
             else:
                 blueprint = self.blueprint_provider.get_blueprint(attr.attribute_type)
                 if attr.is_array():
@@ -98,6 +84,6 @@ class CreateEntity:
                     entity[attr.name] = {}
                 else:
                     entity[attr.name] = self._get_entity(
-                        blueprint=blueprint, parent_type=attr.attribute_type, entity={}
+                        blueprint=blueprint, entity={"name": attr.name, "type": attr.attribute_type},
                     )
         return entity

--- a/api/coverage.txt
+++ b/api/coverage.txt
@@ -29,7 +29,7 @@ core/shared/request_object.py                                 17      3    82.4%
 core/service/document_service.py                             149     23    84.6%   17, 28, 50, 54-57, 71-72, 104, 107, 127-132, 139, 148, 153, 168, 193, 205, 211, 225, 231
 classes/dimension.py                                          38      5    86.8%   16, 20, 38, 53, 58
 services/database.py                                           8      1    87.5%   10
-core/use_case/utils/create_entity.py                          76      8    89.5%   12-13, 16, 21, 46-48, 56
+core/use_case/utils/create_entity.py                          67      8    88.1%   12-13, 16, 21, 46-48, 56
 classes/storage_recipe.py                                     30      3    90.0%   16, 32, 43
 core/enums.py                                                 43      4    90.7%   30-31, 41-42
 classes/blueprint_attribute.py                                33      3    90.9%   36, 47, 61
@@ -40,6 +40,6 @@ tests/core/document_service/test_get.py                       32      1    96.9%
 tests/core/document_service/test_rename.py                    83      2    97.6%   31, 70
 tests/classes/test_tree_node.py                              182      1    99.5%   119
 ------------------------------------------------------------------------------------------
-TOTAL                                                       2406    500    79.2%
+TOTAL                                                       2397    500    79.1%
 
 28 files skipped due to complete coverage.

--- a/api/home/test_data/complex/EngineTest.json
+++ b/api/home/test_data/complex/EngineTest.json
@@ -6,8 +6,7 @@
     {
       "attributeType": "string",
       "type": "system/SIMOS/BlueprintAttribute",
-      "name": "name",
-      "optional": true
+      "name": "name"
     },
     {
       "attributeType": "string",

--- a/api/tests/core/use_case/utils/test_create_entity.py
+++ b/api/tests/core/use_case/utils/test_create_entity.py
@@ -21,9 +21,10 @@ class CreateEntityTestCase(unittest.TestCase):
         expected_entity = {
             "engine2": {},
             "engine": {
+                "name": "engine",
                 "description": "",
                 "fuelPump": {
-                    "name": "fuelpumptest",
+                    "name": "fuelPump",
                     "description": "A standard fuel pump",
                     "type": "ds/test_data/complex/FuelPumpTest",
                 },
@@ -35,7 +36,7 @@ class CreateEntityTestCase(unittest.TestCase):
             "name": "Mercedes",
             "seats": 2,
             "type": "ds/test_data/complex/CarTest",
-            "wheel": {"name": "Wheel", "power": 0.0, "type": "ds/test_data/complex/WheelTest"},
+            "wheel": {"name": "wheel", "power": 0.0, "type": "ds/test_data/complex/WheelTest"},
             "wheels": [],
             "floatValues": [2.1, 3.1, 4.2],
             "intValues": [1, 5, 4, 2],


### PR DESCRIPTION
## What does this pull request change?
* Nested entities gets their name from the name of the attribute describing it.