### PR TITLE
fix names on nested entities in create_entity

### DIFF
--- a/api/tests/core/use_case/utils/test_create_entity.py
+++ b/api/tests/core/use_case/utils/test_create_entity.py
@@ -21,9 +21,10 @@ class CreateEntityTestCase(unittest.TestCase):
         expected_entity = {
             "engine2": {},
             "engine": {
+                # "name": "engine", omitted since name is optional in blueprint.
                 "description": "",
                 "fuelPump": {
-                    "name": "fuelpumptest",
+                    "name": "fuelPump",
                     "description": "A standard fuel pump",
                     "type": "ds/test_data/complex/FuelPumpTest",
                 },
@@ -35,7 +36,7 @@ class CreateEntityTestCase(unittest.TestCase):
             "name": "Mercedes",
             "seats": 2,
             "type": "ds/test_data/complex/CarTest",
-            "wheel": {"name": "Wheel", "power": 0.0, "type": "ds/test_data/complex/WheelTest"},
+            "wheel": {"name": "wheel", "power": 0.0, "type": "ds/test_data/complex/WheelTest"},
             "wheels": [],
             "floatValues": [2.1, 3.1, 4.2],
             "intValues": [1, 5, 4, 2],


### PR DESCRIPTION
## What does this pull request change?
fix bug in name on nested entities.  

## Why is this pull request needed?
nested names on entities should be generated from the parents attribute name, except the root entity name which is user provided.

## Issues related to this change:
