### PR TITLE
fix generate_index read from index plugin ui recipes

### DIFF
--- a/api/classes/blueprint.py
+++ b/api/classes/blueprint.py
@@ -63,7 +63,7 @@ class Blueprint:
     def to_dict_raw(self):
         data = self.dto.data
         if "_id" in data:
-            data.pop('_id')
+            data.pop("_id")
         return data
 
     def to_dict(self):
@@ -92,6 +92,13 @@ class Blueprint:
 
     def get_ui_recipe(self, name=None):
         found = next((x for x in self.ui_recipes if x.name == name), None)
+        if found:
+            return found
+        else:
+            return DefaultRecipe(attributes=[attribute for attribute in self.attributes])
+
+    def get_ui_recipe_by_plugin(self, name=None):
+        found = next((x for x in self.ui_recipes if x.plugin == name), None)
         if found:
             return found
         else:

--- a/api/core/use_case/generate_index_use_case.py
+++ b/api/core/use_case/generate_index_use_case.py
@@ -84,7 +84,7 @@ def is_visible(node):
     if node.parent.blueprint is None:
         return True
 
-    ui_recipe = node.parent.blueprint.get_ui_recipe(name="INDEX")
+    ui_recipe = node.parent.blueprint.get_ui_recipe_by_plugin(name="INDEX")
     return ui_recipe.is_contained(node.attribute, RecipePlugin.INDEX)
 
 

--- a/api/coverage.txt
+++ b/api/coverage.txt
@@ -13,9 +13,9 @@ core/repository/mongo/__init__.py                             30     17    43.3%
 classes/recipe.py                                             57     29    49.1%   32-45, 64, 67-86, 89, 100-101
 tests/classes/test_tree_error_node.py                         15      7    53.3%   29-45
 utils/data_structure/find.py                                  37     16    56.8%   23-24, 28-30, 34-45
+classes/blueprint.py                                          69     28    59.4%   57-61, 64-67, 80, 91, 94-98, 101-105, 108, 114, 117-123
 core/repository/repository_exceptions.py                      15      6    60.0%   3-4, 7, 12, 17, 22
 core/shared/use_case.py                                       13      5    61.5%   8, 11-13, 16
-classes/blueprint.py                                          64     24    62.5%   57-61, 64-67, 80, 91, 94-98, 101, 107, 110-116
 core/repository/repository_factory.py                          8      3    62.5%   8-10
 classes/dto.py                                                48     16    66.7%   19, 23-26, 29-33, 40, 44-45, 53, 57-58, 65
 core/use_case/create_application_use_case.py                 108     36    66.7%   172, 175, 185, 193-194, 200-228, 232-236, 248, 270-272
@@ -40,6 +40,6 @@ tests/core/document_service/test_get.py                       32      1    96.9%
 tests/core/document_service/test_rename.py                    83      2    97.6%   31, 70
 tests/classes/test_tree_node.py                              182      1    99.5%   119
 ------------------------------------------------------------------------------------------
-TOTAL                                                       2421    515    78.7%
+TOTAL                                                       2426    519    78.6%
 
 28 files skipped due to complete coverage.


### PR DESCRIPTION
## What does this pull request change?
visible nodes in index is based on recipes with plugin "INDEX" or index defaults, instead of the name of the ui recipe.

## Why is this pull request needed?
user should not be expected to know that name has a semantic meaning. Plugin is a dropdown which is less error prone. 

## Issues related to this change:
