### PR TITLE
update tree after update document

### DIFF
--- a/web/src/actions.js
+++ b/web/src/actions.js
@@ -72,6 +72,20 @@ async function run({ input, output, updateDocument }) {
   await sleep(5000)
   entity.description = 'c'
   updateDocument({ ...output, entity })
+
+  await sleep(5000)
+  entity['wheels'] = [
+    {
+      name: 'test5',
+      description: '',
+      type: 'SSR-DataSource/CarPackage/Wheel',
+      diameter: 120,
+      pressure: 0,
+      wheelsRecursive: [],
+    },
+  ]
+  output.notify = true
+  updateDocument({ ...output, entity })
 }
 
 async function runResultFile({ input, output, updateDocument }) {

--- a/web/src/pages/common/context-menu-actions/actions/actions.tsx
+++ b/web/src/pages/common/context-menu-actions/actions/actions.tsx
@@ -36,7 +36,13 @@ export type ActionProps = {
 
 export type Method = (props: ActionProps) => any
 
-function updateDocument(output: Output, layout: any) {
+function updateDocument(
+  node: any,
+  output: Output,
+  layout: any,
+  parentId: any,
+  createNodes: Function
+) {
   Api2.put({
     url: `/api/v2/documents/${output.dataSource}/${output.id}`,
     data: output.entity,
@@ -46,10 +52,25 @@ function updateDocument(output: Output, layout: any) {
         NotificationManager.success(
           `updated document: ${response.data.data.name}`
         )
+      refresh(node, output, parentId, createNodes)
     },
     onError: (error: any) => {
       NotificationManager.error(`failed to update document: ${output.id}`)
     },
+  })
+}
+
+function refresh(
+  node: TreeNodeRenderProps,
+  output: any,
+  parentId: string,
+  createNodes: Function
+) {
+  // Create the result node in index tree
+  createNodes({
+    documentId: `${output.id}`,
+    nodeUrl: `/api/v4/index/${output.dataSource}/${parentId}`,
+    node,
   })
 }
 
@@ -70,8 +91,9 @@ export const Action = (
   // @ts-ignore
   const method: Method = Actions[methodToRun]
   const dataSource = node.path.substr(0, node.path.indexOf('/'))
-  async function handleUpdate(output: Output) {
-    await updateDocument(output, layout)
+
+  async function handleUpdate(output: Output, parentId: string) {
+    await updateDocument(node, output, layout, parentId, createNodes)
   }
 
   const input: Input = {

--- a/web/src/pages/common/context-menu-actions/actions/saveToNewFile.tsx
+++ b/web/src/pages/common/context-menu-actions/actions/saveToNewFile.tsx
@@ -62,7 +62,11 @@ export default (
           id: response.data.uid,
         }
 
-        method({ input, output, updateDocument: handleUpdate })
+        const handleUpdateWithTreeUpdate = (output: any) => {
+          handleUpdate(output, formData.destination)
+        }
+
+        method({ input, output, updateDocument: handleUpdateWithTreeUpdate })
       }
 
       await executeAction()


### PR DESCRIPTION
## What does this pull request change?

* After runnable update document, needs to update tree node (s). We do that by fetching a new node structure from the API after each update.

## Why is this pull request needed?

## Issues related to this change:
