### PR TITLE
Restore import / export in context menu

### DIFF
--- a/api/core/use_case/utils/set_index_context_menu.py
+++ b/api/core/use_case/utils/set_index_context_menu.py
@@ -108,7 +108,7 @@ def create_context_menu(node: Node, data_source_id: str, app_settings: dict):
                 get_export_python_code_menu_item(data_source_id=data_source_id, document_id=node.node_id,)
             )
 
-        is_root_package = node.is_single() and node.is_root()
+        is_root_package = node.is_single() and node.type == DMT.PACKAGE.value
 
         # If it's a root package we need some more
         if is_root_package:


### PR DESCRIPTION
## What does this pull request change?
The check for whether a node is a root package, was made more robust, by directly comparing its type to the blueprint package type.

~~The parent of a root package is no longer empty, but rather holds a reference to its data source.~~

## Why is this pull request needed?
The import / export context menu options had disappeared.

## Issues related to this change:
Partly solves #630
