### PR TITLE
Restore import / export in context menu

### DIFF
--- a/api/classes/tree_node.py
+++ b/api/classes/tree_node.py
@@ -415,7 +415,7 @@ class Node(NodeBase):
         self.error_message = None
 
     def is_root(self):
-        return super().is_root()
+        return super().is_root() or self.type == DMT.PACKAGE.value
 
     @property
     def blueprint(self) -> Optional[Blueprint]:


### PR DESCRIPTION
Backport of 7583128698cf9857eaf6aad871eeb9e89bf55401.

Identical to #632 (only for `stable`)