### PR TITLE
support json object as default value

### DIFF
--- a/api/home/test_data/complex/EngineTest.json
+++ b/api/home/test_data/complex/EngineTest.json
@@ -27,7 +27,8 @@
     {
       "type": "system/SIMOS/BlueprintAttribute",
       "attributeType": "ds/test_data/complex/FuelPumpTest",
-      "name": "fuelPump"
+      "name": "fuelPump",
+      "default": "{\"description\":\"A standard fuel pump\",\"name\":\"fuelPump\",\"type\":\"ds/test_data/complex/FuelPumpTest\"}"
     }
   ]
 }

--- a/api/home/test_data/complex/WheelTest.json
+++ b/api/home/test_data/complex/WheelTest.json
@@ -17,7 +17,7 @@
       "name": "power",
       "attributeType": "number",
       "type": "system/SIMOS/BlueprintAttribute",
-      "default": "0"
+      "default": "0.0"
     }
   ]
 }

--- a/api/tests/core/use_case/utils/test_create_entity.py
+++ b/api/tests/core/use_case/utils/test_create_entity.py
@@ -2,6 +2,7 @@ import unittest
 from enum import Enum
 
 from classes.blueprint import Blueprint
+from classes.blueprint_attribute import BlueprintAttribute
 from classes.dto import DTO
 from core.repository.file import TemplateRepositoryFromFile
 from core.use_case.utils.create_entity import CreateEntity
@@ -57,3 +58,15 @@ class CreateEntityTestCase(unittest.TestCase):
         ).entity
 
         self.assertEqual(expected_entity, entity)
+
+    def test_is_not_json(self):
+        self.assertEqual(False, CreateEntity.is_json(BlueprintAttribute(name="", attribute_type="", default="")))
+        self.assertEqual(
+            False, CreateEntity.is_json(BlueprintAttribute(name="", attribute_type="", default=" [] some"))
+        )
+
+    def test_is_json(self):
+        self.assertEqual(True, CreateEntity.is_json(BlueprintAttribute(name="", attribute_type="", default=" [] ")))
+        self.assertEqual(
+            True, CreateEntity.is_json(BlueprintAttribute(name="", attribute_type="", default=' {"foo": "bar"} '))
+        )


### PR DESCRIPTION
## What does this pull request change?
create entity

## Why is this pull request needed?
need to set default object, like this:
```
 "name": "fuelPump",
"default": "{\"description\":\"A standard fuel pump\",\"name\":\"fuelPump\",\"type\":\"ds/test_data/complex/FuelPumpTest\"}"
```
## Issues related to this change:
