### PR TITLE
fetch index and document on none-package clicks

### DIFF
--- a/api/core/use_case/generate_index_use_case.py
+++ b/api/core/use_case/generate_index_use_case.py
@@ -4,7 +4,7 @@ from classes.blueprint_attribute import BlueprintAttribute
 from core.enums import APPLICATION, DMT
 from core.repository.repository_exceptions import EntityNotFoundException
 from core.service.document_service import DocumentService
-from core.use_case.utils.generate_index_menu_actions import get_node_on_select
+from core.use_case.utils.generate_index_menu_actions import get_node_fetch, get_node_index
 from core.use_case.utils.set_index_context_menu import create_context_menu
 from services.data_modelling_document_service import package_api
 from utils.logging import logger
@@ -64,7 +64,8 @@ def get_node(node: Union[Node], data_source_id: str, app_settings: dict) -> Dict
         "type": node.type,
         "meta": {
             "menuItems": menu_items,
-            "onSelect": get_node_on_select(data_source_id, node) if node.is_single() else {},
+            "fetchUrl": get_node_fetch(data_source_id, node) if node.is_single() else {},
+            "indexUrl": get_node_index(data_source_id, node),
             "error": False,
             "isRootPackage": node.type == DMT.PACKAGE.value and node.entity.get("isRoot"),
             "isList": node.is_array(),

--- a/api/core/use_case/utils/generate_index_menu_actions.py
+++ b/api/core/use_case/utils/generate_index_menu_actions.py
@@ -118,15 +118,24 @@ def get_download_menu_action(data_source_id: str, document_id: str):
     }
 
 
-def get_node_on_select(data_source_id: str, tree_node: Union[Node]):
+def get_node_index(data_source_id: str, tree_node: Union[Node]):
+    if tree_node.type in ["datasource"]:
+        return
+    if tree_node.is_empty():
+        return
+    if len(tree_node.children) > 0:
+        if tree_node.parent.type == DMT.ENTITY.value:
+            return get_node_url(data_source_id, tree_node.parent.parent.node_id)
+        return get_node_url(data_source_id, tree_node.parent.node_id)
+
+
+def get_node_fetch(data_source_id: str, tree_node: Union[Node]):
     if tree_node.type in ["datasource"]:
         return
     if tree_node.is_empty():
         return
     if tree_node.type == DMT.PACKAGE.value:
-        if tree_node.parent.type == DMT.ENTITY.value:
-            return get_node_url(data_source_id, tree_node.parent.parent.node_id)
-        return get_node_url(data_source_id, tree_node.parent.node_id)
+        return
 
     split_node_id_attribute = tree_node.node_id.split(".", 1)
     attribute = f"?attribute={split_node_id_attribute[-1]}" if len(split_node_id_attribute) > 1 else ""

--- a/api/reset-application.sh
+++ b/api/reset-application.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 echo "ENVIRONMENT: $ENVIRONMENT"
 
-flask --help
 flask remove-application
 sleep 10
 flask init-application

--- a/web/src/components/tree-view/TreeNode.tsx
+++ b/web/src/components/tree-view/TreeNode.tsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import styled from 'styled-components'
+import { NodeIconType, TreeNodeData } from './Tree'
 import {
   FaChevronDown,
   FaChevronRight,
@@ -8,11 +10,9 @@ import {
   FaFolder,
   FaFolderOpen,
   FaLaptop,
-  FaRegFileAlt,
   FaList,
+  FaRegFileAlt,
 } from 'react-icons/fa'
-import styled from 'styled-components'
-import { NodeIconType, TreeNodeData } from './Tree'
 
 type StyledTreeNode = {
   level: number
@@ -27,17 +27,6 @@ const StyledTreeNode = styled.div`
   &:hover {
     background: lightgray;
   }
-`
-
-type NodeIconProps = {
-  marginRight?: number
-  onClick?: any
-}
-
-const NodeIcon = styled.div`
-  font-size: 12px;
-  margin-right: ${(props: NodeIconProps) =>
-    props.marginRight ? props.marginRight : 5}px;
 `
 
 export type TreeNodeProps = {
@@ -76,6 +65,8 @@ export type TreeNodeRenderProps = {
   parent: string
   nodeData: TreeNodeData
   actions: TreeNodeActions
+  handleToggle: Function
+  iconGroup: Function
 }
 
 const Content = styled.div`
@@ -86,9 +77,19 @@ const ArrowPlaceholderIndent = styled.div`
   width: 12px;
   height: 18px;
 `
+type NodeIconProps = {
+  marginRight?: number
+  onClick?: any
+}
 type Props = {
   node: TreeNodeData
 }
+
+const NodeIcon = styled.div`
+  font-size: 12px;
+  margin-right: ${(props: NodeIconProps) =>
+    props.marginRight ? props.marginRight : 5}px;
+`
 
 const GetIcon = ({ node }: Props) => {
   if (node.meta.error)
@@ -135,36 +136,41 @@ const TreeNode = (props: TreeNodeProps) => {
     actions,
     handleToggle,
   } = props
+
+  const IconGroup = (onClick: Function) => {
+    return (
+      <div
+        style={{ display: 'flex', flexDirection: 'row' }}
+        onClick={() => {
+          onClick()
+          handleToggle(node)
+        }}
+      >
+        <NodeIcon>
+          {node.isExpandable && node.isOpen && <FaChevronDown />}
+          {node.isExpandable && !node.isOpen && <FaChevronRight />}
+          {!node.isExpandable && <ArrowPlaceholderIndent />}
+        </NodeIcon>
+        <NodeIcon marginRight={5}>
+          <GetIcon node={node} />
+        </NodeIcon>
+      </div>
+    )
+  }
+
   const renderProps = {
     path,
     parent,
     nodeData: node,
     actions,
+    handleToggle,
+    iconGroup: IconGroup,
   } as TreeNodeRenderProps
+
   return (
     <div>
       <StyledTreeNode level={level}>
-        <div
-          style={{ display: 'flex', flexDirection: 'row' }}
-          onClick={() => handleToggle(node)}
-        >
-          <NodeIcon>
-            {node.isExpandable && node.isOpen && <FaChevronDown />}
-            {node.isExpandable && !node.isOpen && <FaChevronRight />}
-            {!node.isExpandable && <ArrowPlaceholderIndent />}
-          </NodeIcon>
-          <NodeIcon marginRight={5}>
-            <GetIcon node={node} />
-          </NodeIcon>
-        </div>
-        {node.isFolder && (
-          <Content onClick={() => handleToggle(node)} role="button">
-            {NodeRenderer(renderProps)}
-          </Content>
-        )}
-        {!node.isFolder && (
-          <Content role="button">{NodeRenderer(renderProps)}</Content>
-        )}
+        <Content role="button">{NodeRenderer(renderProps)}</Content>
       </StyledTreeNode>
     </div>
   )

--- a/web/src/pages/common/context-menu-actions/WithContextMenu.tsx
+++ b/web/src/pages/common/context-menu-actions/WithContextMenu.tsx
@@ -15,7 +15,6 @@ interface WithContextMenuProps {
   children: any
   layout: any
   node: TreeNodeRenderProps
-  dataUrl: string
 }
 
 export type SetShowModal = (showModal: boolean) => void

--- a/web/src/plugins/form-rjsf-widgets/BlueprintSelectorWidget.tsx
+++ b/web/src/plugins/form-rjsf-widgets/BlueprintSelectorWidget.tsx
@@ -5,7 +5,7 @@ import { Datasource, DmtApi } from '../../api/Api'
 import DocumentTree from '../../pages/common/tree-view/DocumentTree'
 import { BlueprintEnum } from '../../util/variables'
 import axios from 'axios'
-import { packageOnClick } from '../../pages/common/nodes/DocumentNode'
+import { treeNodeClick } from '../../pages/common/nodes/DocumentNode'
 
 const api = new DmtApi()
 
@@ -65,36 +65,36 @@ export default (props: Props) => {
               const { actions, nodeData } = renderProps
               const [loading, setLoading] = useState(false)
 
-              return (
-                <>
-                  {nodeData.meta.type === blueprintFilter ? (
-                    <div
-                      onClick={() => {
-                        onSelect(`${renderProps.path}/${nodeData.title}`)
-                      }}
-                    >
-                      {nodeData.title}
-                    </div>
-                  ) : (
-                    <div
-                      onClick={() =>
-                        packageOnClick({
-                          onSelect: nodeData.meta.onSelect,
-                          node: { actions, nodeData },
-                          setLoading,
-                        })
-                      }
-                    >
-                      {nodeData.title}
-                      {loading && (
-                        <small style={{ paddingLeft: '15px' }}>
-                          Loading...
-                        </small>
-                      )}
-                    </div>
-                  )}
-                </>
-              )
+              if (nodeData.meta.type === blueprintFilter) {
+                const onClick = () => {
+                  onSelect(`${renderProps.path}/${nodeData.title}`)
+                }
+                return (
+                  <div
+                    style={{ display: 'flex', flexDirection: 'row' }}
+                    onClick={onClick}
+                  >
+                    {renderProps.iconGroup(onClick)}
+                    {nodeData.title}
+                  </div>
+                )
+              } else {
+                return (
+                  <div style={{ display: 'flex', flexDirection: 'row' }}>
+                    {renderProps.iconGroup(
+                      treeNodeClick({
+                        indexUrl: nodeData.meta.indexUrl,
+                        node: { actions, nodeData },
+                        setLoading,
+                      })
+                    )}
+                    {nodeData.title}
+                    {loading && (
+                      <small style={{ paddingLeft: '15px' }}>Loading...</small>
+                    )}
+                  </div>
+                )
+              }
             }}
             dataSources={datasources}
           />


### PR DESCRIPTION
## What does this pull request change?
* index passes fetchURL and indexURL instead of the ambiguous "onSelect" prop
* clicks on documents fetches child index and the document itself
* Fixes bug where clicking the arrow in the tree view would not fetch the document

