### PR TITLE
fix bug on schemaGenerator to allow widget on arrays

### DIFF
--- a/api/classes/blueprint.py
+++ b/api/classes/blueprint.py
@@ -26,7 +26,8 @@ def get_ui_recipe(recipes: List[Dict]):
                 RecipeAttribute(
                     name=attr["name"],
                     is_contained=attr.get("contained", True),
-                    field=attr.get("field"),
+                    for_each_element=attr.get("forEachElement", True),
+                    field=attr.get("field", None),
                     collapsible=attr.get("collapsible", None),
                     ui_recipe=attr.get("uiRecipe", None),
                     mapping=attr.get("mapping", None),

--- a/api/classes/recipe.py
+++ b/api/classes/recipe.py
@@ -16,6 +16,7 @@ class RecipeAttribute:
         self,
         name: str,
         is_contained: bool,
+        for_each_element: bool = True,
         field: str = None,
         collapsible: bool = None,
         ui_recipe: str = None,
@@ -23,6 +24,7 @@ class RecipeAttribute:
     ):
         self.name = name
         self.is_contained = is_contained
+        self.for_each_element = for_each_element
         self.field = field
         self.collapsible = collapsible
         self.ui_recipe = ui_recipe
@@ -94,5 +96,7 @@ class Recipe:
 
 class DefaultRecipe(Recipe):
     def __init__(self, attributes: List[BlueprintAttribute]):
-        recipe_attributes = [RecipeAttribute(name=attr.name, is_contained=True) for attr in attributes]
+        recipe_attributes = [
+            RecipeAttribute(name=attr.name, is_contained=True, for_each_element=True) for attr in attributes
+        ]
         super().__init__("Default", attributes=recipe_attributes)

--- a/web/src/plugins/form-rjsf-widgets/MultiSelectorWidget.tsx
+++ b/web/src/plugins/form-rjsf-widgets/MultiSelectorWidget.tsx
@@ -7,12 +7,18 @@ import DocumentTree from '../../pages/common/tree-view/DocumentTree'
 import Modal from '../../components/modal/Modal'
 import { FaTimes } from 'react-icons/fa'
 import { BlueprintEnum } from '../../util/variables'
+import { treeNodeClick } from '../../pages/common/nodes/DocumentNode'
 
 const api = new DmtApi()
 
 const NodeWrapper = styled.div`
   display: flex;
   justify-content: space-between;
+  flex-direction: row;
+`
+const IconTitleWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
 `
 const ButtonWrapper = styled.div`
   display: flex;
@@ -56,8 +62,15 @@ const MultiSelector = ({
   uiSchema,
   typeFilter,
 }: MultiSelectorProps) => {
+  let initialState = formData
+  if (!Array.isArray(formData)) {
+    initialState = [formData]
+  }
+
   const [datasources, setDatasources] = useState<Datasource[]>([])
-  const [selectedPackages, setSelectedPackages] = useState<string[]>(formData)
+  const [selectedPackages, setSelectedPackages] = useState<string[]>(
+    initialState
+  )
   const [showModal, setShowModal] = useState<boolean>(false)
 
   function removePackage(value: string) {
@@ -70,11 +83,7 @@ const MultiSelector = ({
 
   function handleChange(value: string) {
     if (selectedPackages.includes(value)) {
-      setSelectedPackages(
-        selectedPackages.filter(e => {
-          return e !== value
-        })
-      )
+      setSelectedPackages(selectedPackages.filter(e => e !== value))
       onChange(selectedPackages)
     } else {
       selectedPackages.push(value)
@@ -143,12 +152,23 @@ const MultiSelector = ({
       >
         <DocumentTree
           render={(renderProps: TreeNodeRenderProps) => {
-            const { nodeData } = renderProps
+            const { nodeData, actions } = renderProps
             const value = `${renderProps.path}/${nodeData.title}`
 
             return (
               <NodeWrapper>
-                {nodeData.title}
+                <IconTitleWrapper
+                  onClick={() => {
+                    treeNodeClick({
+                      indexUrl: nodeData.meta.indexUrl,
+                      node: { actions, nodeData },
+                      setLoading: () => {},
+                    })
+                  }}
+                >
+                  {renderProps.iconGroup(() => {})}
+                  {nodeData.title}
+                </IconTitleWrapper>
                 {typeFilter(nodeData) && (
                   <input
                     type={'checkbox'}
@@ -184,6 +204,7 @@ export const BlueprintsSelector = ({ onChange, formData, uiSchema }: any) => {
   function BlueprintsFilter(nodeData: any) {
     return nodeData?.meta?.type === BlueprintEnum.BLUEPRINT
   }
+
   return MultiSelector({
     onChange,
     formData,

--- a/web/src/plugins/form_rjsf_edit/BlueprintUiSchema.ts
+++ b/web/src/plugins/form_rjsf_edit/BlueprintUiSchema.ts
@@ -133,7 +133,11 @@ export class BlueprintUiSchema extends Blueprint implements IBlueprintSchema {
     uiAttr: any
   ) {
     if (attr.isArray()) {
-      const newPath = path + '.items'
+      let newPath = path + '.items'
+      // if 'forEachElement' is false on a uiAttribute, don't apply the widget to every child. But to the entire array
+      if (uiAttr?.forEachElement === false) {
+        newPath = path
+      }
       objectPath.set(this.schema, newPath, {})
       this.appendSchemaProperty(newPath, blueprint, attr, uiAttr)
     } else {


### PR DESCRIPTION
## What does this pull request change?
*  Update the front end schema generator to respect the new "forEachElement" attribute

## Why is this pull request needed?
* Changed behaviour of the ui:field attribute in the SchemaGenerator broke some components using widgets on arrays

## Issues related to this change:
