### PR TITLE
default uvicorn don't support websockets, so no upgrade

### DIFF
--- a/nginx/default.nginx
+++ b/nginx/default.nginx
@@ -10,8 +10,6 @@ server {
         proxy_pass http://mainapi:5000/api/;
 
         proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection upgrade;
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-For $remote_addr;


### PR DESCRIPTION
## What does this pull request change?
 Don't upgrade connection to websockets

## Why is this pull request needed?
Needed by https://github.com/equinor/data-modelling-storage-service/pull/63 fastAPI
