### PR TITLE
remove depreciated set-env command

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -79,7 +79,7 @@ jobs:
 
       - name: "Set ENV variables"
         run: |
-          echo "COMMIT_REF=$(git rev-parse --short $GITHUB_SHA)"
+          echo "COMMIT_REF=$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
 
       - name: "Build and Publish Web"
         run: |
@@ -102,7 +102,7 @@ jobs:
 
       - name: "Set ENV variables"
         run: |
-          echo "COMMIT_REF=$(git rev-parse --short $GITHUB_SHA)"
+          echo "COMMIT_REF=$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
 
       - name: "Build and Publish API"
         run: |


### PR DESCRIPTION
## What does this pull request change?
update github actions

## Why is this pull request needed?
CI fails due to the use of a depreciated github action command "set-env"
(https://stackoverflow.com/questions/57968497/how-do-i-set-an-env-var-with-a-bash-expression-in-github-actions)

## Issues related to this change:
