### PR TITLE
modal for blueprint picker appear in front 

### DIFF
--- a/web/plugins/common/src/components/Modal/style.ts
+++ b/web/plugins/common/src/components/Modal/style.ts
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 const ModalWrapper = styled.div`
   position: fixed;
-  z-index: 1;
+  z-index: 3;
   padding-top: 100px;
   left: 0;
   top: 0;


### PR DESCRIPTION

## What does this pull request change?
make modal for blueprint picker appear in front of other modals (for example, when on the Entity page, right click on package -> New Entity -> click on type will open the blueprint picker modal.)

## Why is this pull request needed?
bugfix
## Issues related to this change:

## Checklist

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added types and interfaces where possible
- [x] You have added tests
- [x] You have updated documentation
- [x] You use defined architecture principles and project structures
- [x] You are happy with the code quality
