### PR TITLE
bugfix: update name 

### DIFF
--- a/web/app/src/hooks/useExplorer.test.tsx
+++ b/web/app/src/hooks/useExplorer.test.tsx
@@ -166,7 +166,8 @@ describe('the explorer hook', () => {
         open: expect.any(Function),
         create: expect.any(Function),
         remove: expect.any(Function),
-        update: expect.any(Function),
+        rename: expect.any(Function),
+        updateById: expect.any(Function)
       })
     })
     it('should contain two documents in the tree', () => {
@@ -473,13 +474,13 @@ describe('the explorer hook', () => {
     })
   })
 
-  describe('when update is called', () => {
+  describe('when rename is called', () => {
     describe('and documentApi returns a resolved promise', () => {
       beforeEach(async () => {
         const updatedDocument = {
           uid: '1',
         }
-        mocks.documentApi.update.mockReturnValue(
+        mocks.documentApi.explorerRename.mockReturnValue(
           Promise.resolve(updatedDocument)
         )
 
@@ -499,18 +500,17 @@ describe('the explorer hook', () => {
           Promise.resolve(indexNodes)
         )
         await act(async () => {
-          response.result.current.update({
-            data: {
-              name: 'New name',
-            },
-            updateUrl: '/',
+          response.result.current.rename({
+            dataSourceId: 'localhost',
+            documentId: '1',
             nodeUrl: '/',
+            renameData: { name: 'New name', parentId: null },
           })
         })
       })
 
       it('should the document be updated to the server', async () => {
-        expect(mocks.documentApi.update).toHaveBeenCalledTimes(1)
+        expect(mocks.documentApi.explorerRename).toHaveBeenCalledTimes(1)
       })
       it('should the document be updated in the tree', async () => {
         expect(mocks.indexApi.getIndexByDocument).toHaveBeenCalledTimes(1)
@@ -540,23 +540,22 @@ describe('the explorer hook', () => {
 
     describe('on a documentApi returns a rejected promise', () => {
       beforeEach(async () => {
-        mocks.documentApi.update.mockReturnValue(
+        mocks.documentApi.explorerRename.mockReturnValue(
           Promise.reject(new Error('error'))
         )
 
         await act(async () => {
-          response.result.current.update({
-            data: {
-              name: 'New name',
-            },
-            updateUrl: '/',
+          response.result.current.rename({
+            dataSourceId: 'localhost',
+            documentId: '1',
             nodeUrl: '/',
+            renameData: { name: 'New name', parentId: null },
           })
         })
       })
       it('should create an errorMessage', () => {
         expect(response.result.current.errorMessage).toBe(
-          'Could not update selected document. (Error: error)'
+          'Could not rename selected document. (Error: error)'
         )
       })
     })

--- a/web/app/src/pages/editor/document-explorer/DocumentActions.tsx
+++ b/web/app/src/pages/editor/document-explorer/DocumentActions.tsx
@@ -1,7 +1,10 @@
 import React, { useState } from 'react'
 import Prompt from '../../../components/Prompt'
 import useRunnable from '../../../hooks/useRunnable'
-import useExplorer, { IUseExplorer } from '../../../hooks/useExplorer'
+import useExplorer, {
+  IUseExplorer,
+  RenameData,
+} from '../../../hooks/useExplorer'
 import {
   BlueprintEnum,
   BlueprintPicker,
@@ -105,6 +108,14 @@ export interface IInsertReferenceProps {
   targetDataSource: string
 }
 
+export interface IRenameDocument {
+  explorer: IUseExplorer
+  nodeUrl: string
+  node: any
+  dataSourceId: string
+  documentId: string
+}
+
 // todo - temporary solution for create form - should be updated later
 export interface IDefaultCreate {
   explorer: IUseExplorer
@@ -184,6 +195,45 @@ export const DefaultCreate = (props: IDefaultCreate) => {
       onSubmit={() => onSubmit()}
       content={modalContent()}
       buttonText={'Create'}
+    />
+  )
+}
+
+// todo temprorary solution for form - can be replaced with react-jsonschema-form later
+export const RenameDocument = (props: IRenameDocument) => {
+  const [name, setName] = useState<string>(props.node.nodeData.title)
+  const { explorer, nodeUrl, node, dataSourceId, documentId } = props
+
+  const onSubmit = () => {
+    const parentId: string = node.parent
+    const renameData: RenameData = {
+      name: name,
+      parentId: node.nodeData.meta.isRootPackage ? null : parentId,
+    }
+    explorer.rename({ dataSourceId, documentId, nodeUrl, renameData })
+  }
+
+  const modalContent = () => {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <div style={{ margin: '10px 0' }}>
+          <label style={{ marginRight: '10px' }}>New name: </label>
+          <input
+            disabled={false}
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            style={{ width: '280px' }}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <Prompt
+      onSubmit={() => onSubmit()}
+      content={modalContent()}
+      buttonText={'Update name'}
     />
   )
 }

--- a/web/app/src/pages/editor/document-explorer/DocumentExplorer.tsx
+++ b/web/app/src/pages/editor/document-explorer/DocumentExplorer.tsx
@@ -10,6 +10,7 @@ import {
   InsertReference,
   DefaultCreate,
   SaveToExistingDocument,
+  RenameDocument,
 } from './DocumentActions'
 import ContextMenu from '../../../components/context-menu/ContextMenu'
 import { useModalContext } from '../../../context/modal/ModalContext'
@@ -85,26 +86,19 @@ export default () => {
         })
         break
       case ContextMenuActions.UPDATE:
-        const updateProps = {
+        const dataSourceId: string | undefined = node.nodeData.meta.dataSource
+        const documentId: string = node.nodeData.nodeId
+
+        const renameProps = {
           explorer: explorer,
-          uiRecipeName: 'DEFAULT_CREATE',
-          dataSourceId: node.nodeData.meta.dataSource,
-          documentId: node.nodeData.nodeId,
-          onSubmit: (formData: any) => {
-            if (formData.description === undefined) {
-              formData.description = ''
-            }
-            const output = formDataGivenByRequest(data.request, formData)
-            explorer.update({
-              data: output,
-              updateUrl: data.url,
-              nodeUrl: data.nodeUrl,
-            })
-          },
+          nodeUrl: data.nodeUrl,
+          node: node,
+          dataSourceId: dataSourceId,
+          documentId: documentId,
         }
-        openModal(ExternalPlugin, {
-          dialog: { title: `Update ${node.nodeData.nodeId}` },
-          props: updateProps,
+        openModal(RenameDocument, {
+          dialog: { title: `Rename ${node.nodeData.nodeId}` },
+          props: renameProps,
         })
         break
       case ContextMenuActions.DELETE: {

--- a/web/plugins/common/src/services/api/DocumentAPI.tsx
+++ b/web/plugins/common/src/services/api/DocumentAPI.tsx
@@ -1,6 +1,7 @@
 import { IDocumentAPI } from './interfaces/DocumentAPI'
 import apiProvider from './utilities/Provider'
 import { dmssApi } from './configs/StorageServiceAPI'
+import { RenameRequest } from './configs/gen'
 
 export class DocumentAPI implements IDocumentAPI {
   create(url: string, data: any): Promise<any> {
@@ -44,6 +45,13 @@ export class DocumentAPI implements IDocumentAPI {
 
   update(url: string, data: any): Promise<any> {
     return dmssApi.documentUpdate(data)
+  }
+
+  explorerRename(
+    dataSourceId: string,
+    renameRequest: RenameRequest
+  ): Promise<any> {
+    return dmssApi.explorerRename({ dataSourceId, renameRequest })
   }
 
   search(dataSourceId: string, query: any): Promise<any> {

--- a/web/plugins/common/src/services/api/interfaces/DocumentAPI.tsx
+++ b/web/plugins/common/src/services/api/interfaces/DocumentAPI.tsx
@@ -1,9 +1,16 @@
+import { RenameRequest } from '../configs/gen'
+
 export interface IDocumentAPI {
   create(url: string, data: any): Promise<any>
 
   remove(url: string, data: any): Promise<any>
 
   update(url: string, data: any): Promise<any>
+
+  explorerRename(
+    dataSourceId: string,
+    renameRequest: RenameRequest
+  ): Promise<any>
 
   updateById(
     dataSourceId: string,


### PR DESCRIPTION
## What does this pull request change?
fix bug: right click -> update does not work

Updated UseExplorer hook to use a rename from documentAPI instead of the previous update function


## Why is this pull request needed?
bugfix

## Issues related to this change:
#825 

## Checklist

- [X] Your code builds clean without any errors or warnings
- [X] You are using approved terminology
- [X] You have added types and interfaces where possible
- [X] You have added tests
- [] You have updated documentation
- [X] You use defined architecture principles and project structures
- [X] You are happy with the code quality
