### PR TITLE
fix: editable type on create Entity

### DIFF
--- a/web/plugins/common/src/components/Pickers/BlueprintPicker.tsx
+++ b/web/plugins/common/src/components/Pickers/BlueprintPicker.tsx
@@ -2,13 +2,15 @@
 import React, { useState } from 'react'
 import { BlueprintEnum } from '../../utils/variables'
 import {
+  Application,
   DataSourceAPI,
+  IIndex,
   Modal,
   Tree,
   TreeNodeRenderProps,
   useDataSources,
+  useIndex,
 } from '../../'
-import { IIndex, useIndex, Application } from '../../'
 import { IDataSources } from '../../hooks/useDataSources'
 
 export type BlueprintPickerProps = {
@@ -98,7 +100,7 @@ export const BlueprintPicker = (props: BlueprintPickerProps) => {
       )}
       <div style={{ width: '100%' }}>
         <input
-          style={{ width: '100%', borderRadius: '5px' }}
+          style={{ width: '280px', borderRadius: '5px' }}
           type="string"
           value={formData}
           readOnly={true}


### PR DESCRIPTION
## What does this pull request change?
- Added the BlueprintPicker as type input in action Create Entity, instead of a disabled <input> 

## Why is this pull request needed?
- Need to be able to select which type the new entity should have

## Issues related to this change:
closes #826 