### PR TITLE
bug: index only return first level on root package

### DIFF
--- a/api/src/home/DMT/data/DMT-DS/DMT/actions/NewActionResult.json
+++ b/api/src/home/DMT/data/DMT-DS/DMT/actions/NewActionResult.json
@@ -26,6 +26,7 @@
     {
       "type": "system/SIMOS/UiRecipe",
       "name": "DEFAULT_CREATE",
+      "plugin": "DEFAULT_CREATE",
       "description": "",
       "attributes": [
         {

--- a/api/src/home/EntityApp/settings.json
+++ b/api/src/home/EntityApp/settings.json
@@ -18,6 +18,14 @@
       "actionType": "resultInEntity"
     },
     {
+      "name": "Run 234",
+      "description": "Simulate a category 3 storm",
+      "input": "EntityApp-DS/DMT-demo/ControlIndex/HasComplexAttribute",
+      "output": "EntityApp-DS/DMT-demo/ControlIndex/HasComplexAttribute",
+      "method": "simulateCat3StormResultInEntity",
+      "actionType": "resultInEntity"
+    },
+    {
       "name": "Cancel Simulation",
       "description": "Cancel started simulation",
       "input": "EntityApp-DS/DMT-demo/Actions/WindTurbineWithAction",

--- a/api/src/use_case/generate_index_use_case.py
+++ b/api/src/use_case/generate_index_use_case.py
@@ -2,7 +2,7 @@ from typing import Dict, Union
 
 from config import config
 from domain_classes.blueprint_attribute import BlueprintAttribute
-from domain_classes.recipe import RecipePlugin
+from domain_classes.recipe import Recipe, RecipePlugin
 from domain_classes.tree_node import ListNode, Node
 from enums import BLUEPRINTS
 from repository.repository_exceptions import ApplicationNotLoadedException, EntityNotFoundException
@@ -90,7 +90,7 @@ def is_visible(node):
     if node.parent.blueprint is None:
         return True
 
-    ui_recipe = node.parent.blueprint.get_ui_recipe_by_plugin(name="INDEX")
+    ui_recipe: Recipe = node.parent.blueprint.get_ui_recipe_by_plugin(name="INDEX")
     return ui_recipe.is_contained(node.attribute, RecipePlugin.INDEX)
 
 
@@ -202,7 +202,7 @@ class GenerateSingleIndexUseCase(UseCase):
                 attribute=BlueprintAttribute("root", "datasource", contained=True),
             )
             parent.add_child(
-                document_service.get_node_by_uid(data_source_id=data_source_id, document_uid=document_id, depth=0)
+                document_service.get_node_by_uid(data_source_id=data_source_id, document_uid=document_id, depth=1)
             )
         else:
             parent = document_service.get_node_by_uid(data_source_id=data_source_id, document_uid=parent_uid, depth=1)

--- a/api/src/use_case/import_package.py
+++ b/api/src/use_case/import_package.py
@@ -143,7 +143,6 @@ def import_package_tree(root_package: Package, data_source_id: str) -> None:
     with IncrementalBar(
         f"Importing {root_package.name}",
         max=len(documents_to_upload),
-        fill="*",
         suffix="%(percent).0f%% - [%(eta)ds/%(elapsed)ds]",
     ) as bar:
         for document in documents_to_upload:

--- a/web/app/src/pages/editor/layout-components/DocumentComponent.tsx
+++ b/web/app/src/pages/editor/layout-components/DocumentComponent.tsx
@@ -44,12 +44,14 @@ const View = (props: any) => {
   if (loading) return <div>Loading...</div>
 
   const ExternalPlugin = getUIPlugin(uiRecipe.plugin)
+  // rjsf-form is the only plugin that needs this uiRecipe name
   return (
     <ExternalPlugin
       dataSourceId={dataSourceId}
       documentId={documentId}
       explorer={explorer}
       uiRecipe={uiRecipe}
+      uiRecipeName={uiRecipe.name}
       updateDocument={onSubmit}
       document={document}
       fetchBlueprint={fetchBlueprint}

--- a/web/plugins/default-form/src/index.tsx
+++ b/web/plugins/default-form/src/index.tsx
@@ -19,7 +19,14 @@ import {
 } from '@dmt/common'
 
 const PluginComponent = (props: DmtUIPlugin) => {
-  const { type, documentId, dataSourceId, uiRecipe, explorer, onSubmit } = props
+  const {
+    type,
+    documentId,
+    dataSourceId,
+    uiRecipeName,
+    explorer,
+    onSubmit,
+  } = props
 
   const [document, setDocument] = useState(undefined)
   const [documentType, setDocumentType] = useState(type)
@@ -54,7 +61,7 @@ const PluginComponent = (props: DmtUIPlugin) => {
       createFormConfigs({
         type: documentType,
         document,
-        name: uiRecipe.name,
+        uiRecipeName,
         explorer,
       })
         // @ts-ignore
@@ -65,7 +72,7 @@ const PluginComponent = (props: DmtUIPlugin) => {
           )
         })
     }
-  }, [documentType, config, document, uiRecipe])
+  }, [documentType, config, document, uiRecipeName])
 
   if (!config) return <div>Getting config...</div>
 
@@ -105,7 +112,7 @@ const PluginComponent = (props: DmtUIPlugin) => {
 
 /**
  * Fundamental client side validation.
- * Ensure only valid entities are posted.
+ * Ensure only valid entities are posted. s
  *
  * @todo set defaults in formData passed to form.
  * @param blueprint

--- a/web/plugins/yaml-view/src/YamlPlugin.tsx
+++ b/web/plugins/yaml-view/src/YamlPlugin.tsx
@@ -25,7 +25,7 @@ export default (props: PreviewProps) => {
           <button style={{ marginBottom: '5px' }}>Copy</button>
         </CopyToClipboard>
       </div>
-      <pre style={{ backgroundColor: '#193549' }}>
+      <pre style={{ backgroundColor: '#193549', color: 'coral' }}>
         <code dangerouslySetInnerHTML={{ __html: highlighted.value }} />
       </pre>
     </div>


### PR DESCRIPTION
## What does this pull request change?
- Fixes bug with where the index fetched on a root package only goes one level down.
- Revert changes where uiRecipeName was removed from PluginProps, as this is used by default-form on contextActions

## Why is this pull request needed?
- User need to be able to view/click nested entities, also on root package level

## Issues related to this change:
closes #859  
