### PR TITLE
update override type functionality

### DIFF
--- a/web/app/src/components/Prompt.tsx
+++ b/web/app/src/components/Prompt.tsx
@@ -6,7 +6,7 @@ const Prompt = (props: any) => {
     <div>
       <h4>{title}</h4>
       {content}
-      <div style={{ textAlign: 'center' }}>
+      <div style={{ textAlign: 'center', paddingTop: '10px' }}>
         <button onClick={() => onSubmit()}>{buttonText}</button>
       </div>
     </div>

--- a/web/app/src/pages/editor/document-explorer/DocumentActions.tsx
+++ b/web/app/src/pages/editor/document-explorer/DocumentActions.tsx
@@ -10,6 +10,7 @@ import {
   BlueprintPicker,
   EntityPicker,
   Reference,
+  OverrideTypeButton,
 } from '@dmt/common'
 
 export enum ContextMenuActions {
@@ -132,6 +133,8 @@ export const DefaultCreate = (props: IDefaultCreate) => {
   const [type, setType] = useState<string>(defaultType)
   const [name, setName] = useState<string>('')
   const [description, setDescription] = useState<string>('')
+  // @ts-ignore
+  const canOverrideType = !Object.values(BlueprintEnum).includes(props.type)
 
   const onSubmit = () => {
     props.explorer.create({
@@ -151,54 +154,59 @@ export const DefaultCreate = (props: IDefaultCreate) => {
 
   const modalContent = () => {
     return (
-      <div style={{ display: 'flex', flexDirection: 'column' }}>
-        <div style={{ margin: '10px 0' }}>
-          <label style={{ marginRight: '10px' }}>Name: </label>
+      <div style={{ display: 'table', borderSpacing: '10px' }}>
+        <div style={{ display: 'table-row' }}>
+          <label style={{ display: 'table-cell' }}>Name: </label>
           <input
             disabled={false}
             value={name}
             onChange={(event) => setName(event.target.value)}
-            style={{ width: '280px' }}
+            style={{ width: '280px', display: 'table-cell' }}
           />
         </div>
-        <div
-          style={{ marginTop: '10px', display: 'flex', flexDirection: 'row' }}
-        >
-          <label style={{ marginRight: '10px' }}>Type: </label>
+        <div style={{ display: 'table-row', flexDirection: 'row' }}>
+          <label style={{ display: 'table-cell' }}>Type: </label>
           {/* If we are to create an "Entity", user should select type*/}
-          {props.type === BlueprintEnum.ENTITY ? (
-            <BlueprintPicker
-              formData={type}
-              onChange={(value: string) => setType(value)}
-              uiSchema={{ 'ui:label': '' }}
-            />
-          ) : (
-            <div>
-              {/*todo - make sure that user can only select blueprints that
-                extends the current "type". perhaps need to create an
-                "ExtendsFromBlueprintPicker".
-                */}
-              <input disabled={true} value={type} style={{ width: '280px' }} />
-              <div style={{ marginTop: '10px' }}>
-                <label style={{ marginRight: '10px' }}>Override type? </label>
-
-                <BlueprintPicker
-                  formData={type}
-                  onChange={(value: string) => setType(value)}
-                  uiSchema={{ 'ui:label': '' }}
+          <div style={{ display: 'flex', borderSpacing: '0px' }}>
+            {props.type === BlueprintEnum.ENTITY ? (
+              <BlueprintPicker
+                formData={type}
+                onChange={(value: string) => setType(value)}
+                uiSchema={{ 'ui:label': '' }}
+              />
+            ) : (
+              <div style={{ display: 'flex' }}>
+                <input
+                  disabled={true}
+                  value={type}
+                  style={{ width: '280px' }}
                 />
+                {canOverrideType ? (
+                  <div style={{ paddingLeft: '10px' }}>
+                    <OverrideTypeButton
+                      formData={type}
+                      onChange={(value: string) => setType(value)}
+                    />
+                  </div>
+                ) : (
+                  <div></div>
+                )}
               </div>
-            </div>
-          )}
+            )}
+          </div>
         </div>
-        <div style={{ marginTop: '10px' }}>
-          <label style={{ marginRight: '10px' }}>Description: </label>
-          <input
-            disabled={false}
-            value={description}
-            onChange={(event) => setDescription(event.target.value)}
-            style={{ width: '280px' }}
-          />
+        <div style={{ display: 'table-row' }}>
+          <label style={{ marginRight: '10px', display: 'table-cell' }}>
+            Description:{' '}
+          </label>
+          <div style={{ display: 'table-cell' }}>
+            <input
+              disabled={false}
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              style={{ width: '280px' }}
+            />
+          </div>
         </div>
       </div>
     )

--- a/web/plugins/common/src/components/Button/OverrideTypeButton.tsx
+++ b/web/plugins/common/src/components/Button/OverrideTypeButton.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react'
+import { Modal } from '../Modal'
+import { BlueprintEnum } from '../../utils/variables'
+import { Selector } from '../Pickers'
+
+export type OverrideTypeButtonProps = {
+  onChange: Function
+  formData: any
+  blueprintFilter?: BlueprintEnum
+}
+
+export const OverrideTypeButton = (props: OverrideTypeButtonProps) => {
+  const { onChange, blueprintFilter = BlueprintEnum.BLUEPRINT } = props
+  const [showModal, setShowModal] = useState<boolean>(false)
+
+  const selectorProps = {
+    setShowModal,
+    onChange,
+    blueprintFilter,
+  }
+
+  return (
+    <div>
+      <button onClick={() => setShowModal(!showModal)}>Override type</button>
+      <Modal
+        toggle={() => setShowModal(!showModal)}
+        open={showModal}
+        title={'Select a blueprint as type'}
+      >
+        <Selector {...selectorProps} />
+      </Modal>
+    </div>
+  )
+}

--- a/web/plugins/common/src/components/Button/index.tsx
+++ b/web/plugins/common/src/components/Button/index.tsx
@@ -1,1 +1,2 @@
 export * from './Button'
+export * from './OverrideTypeButton'


### PR DESCRIPTION
## What does this pull request change?
* update UI for override type - use button
* hide "override type" functionality for Package, Blueprint, etc...

## Why is this pull request needed?
override type should not be visible on all document types (Package, Blueprint, etc)

## Issues related to this change:
closes #882 
## Checklist

- [x] Your code builds clean without any errors or warnings
- [x] You are using approved terminology
- [x] You have added types and interfaces where possible
- [ ] You have added tests
- [ ] You have updated documentation
- [x] You use defined architecture principles and project structures
- [x] You are happy with the code quality
