### PR TITLE
display error message if type is not selected by user

### DIFF
--- a/web/app/src/hooks/useExplorer.tsx
+++ b/web/app/src/hooks/useExplorer.tsx
@@ -173,7 +173,7 @@ export default function useExplorer(props: ExplorerProps): IUseExplorer {
       setErrorMessage(errorMessage)
       return false
     }
-    if (data.type === BlueprintEnum.ENTITY || data.type === undefined) {
+    if (data.type === BlueprintEnum.ENTITY || data.type === undefined || data.type === "Click to select type to create") {
       const errorMessage: string = 'Type is required'
       setErrorMessage(errorMessage)
       return false


### PR DESCRIPTION
## What does this pull request change?
update useExplorer validation to fail when the type is set to the default text
## Why is this pull request needed?
error message not displayed when type is not selected in blueprint picker
## Issues related to this change:

