### PR TITLE
supply token on CLI on import (reset-app)

### DIFF
--- a/api/src/app.py
+++ b/api/src/app.py
@@ -39,7 +39,9 @@ app = create_app(config)
 
 
 @click.group()
-def cli():
+@click.option("--token", default="no-token", type=str)
+def cli(token: str):
+    dmss_api.api_client.default_headers["Authorization"] = "Bearer " + token
     pass
 
 
@@ -105,7 +107,7 @@ def init_application():
 
         logger.debug("_____ DONE importing data sources _____")
 
-        logger.debug(f"_____ importing blueprints and entities {tuple(settings.get('packages',[]))}_____")
+        logger.debug(f"_____ importing blueprints and entities {tuple(settings.get('packages', []))}_____")
         for package in settings.get("packages", []):
             data_source_alias, folder = package.split("/", 1)
             actual_data_source = settings["data_source_aliases"].get(data_source_alias, data_source_alias)
@@ -128,7 +130,7 @@ def init_application():
                 import_package_tree(root_package, actual_data_source)
             except Exception as error:
                 raise Exception(f"Something went wrong trying to upload the package ''{package}'' to DMSS; {error}")
-        logger.debug(f"_____ DONE importing blueprints and entities {tuple(settings.get('packages',[]))}_____")
+        logger.debug(f"_____ DONE importing blueprints and entities {tuple(settings.get('packages', []))}_____")
 
     logger.debug("_____ importing blobs _____")
     # TODO:  This is a temporary fix for import of blob data.

--- a/api/src/init.sh
+++ b/api/src/init.sh
@@ -40,7 +40,10 @@ if [ "$ENVIRON" = 'local' ] && [ "$FLA_ENV" = 'development' ]; then
 fi
 
 if [ "$1" = 'reset-app' ]; then
-  python /code/app.py reset-app
+  service_is_ready
+  shift
+  # This is quite bad. Only allows for CLI arguments before 'reset-app' subcommand.
+  python /code/app.py "$@" reset-app
   exit 0
 fi
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -33,6 +33,8 @@ services:
   web:
     build:
       target: development
+      args:
+        AUTH_ENABLED: 1
     image: web-dev
     stdin_open: true
     volumes:

--- a/docs/developer-manual.adoc
+++ b/docs/developer-manual.adoc
@@ -69,14 +69,24 @@ The DMT will be available at http://localhost
 docker-compose down
 ----
 
-==== Reset database
+==== Import data and reset database
 
-To re-import blueprints and entities (from /api/home directory).
+Import local documents to the configured DMSS_HOST (from /api/home directory).
+Token is optional, but required if DMSS is configured with authentication.
+Token can be acquired from the DMT Web application .
 
 [source, bash]
 ----
-docker-compose run --rm api ./reset-application.sh
+docker-compose run --rm api reset-app --token=Eyxx.xxxx.xxxx
 ----
+
+If the data is corrupted or in a bad state some way, a hard reset of the DMSS is often a solution.
+This command will remove every _mongo database using the same database host as the core_, and upload DMSS's core documents.
+[source, bash]
+----
+docker-compose run --rm dmss reset-app
+----
+
 
 ==== Running Tests
 

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,14 +1,16 @@
 FROM node:12-alpine as base
 
-
-ENV REACT_APP_AUTH=0
+ARG AUTH_ENABLED=0
+ARG REDIRECT_URI=http://localhost/
+ARG AUTH_SCOPE=api://97a6b5bd-63fb-42c6-bb75-7e5de2394ba0/dmss_test_scope
+ENV REACT_APP_AUTH=$AUTH_ENABLED
 ENV REACT_APP_AUTH_CLIENT_ID=97a6b5bd-63fb-42c6-bb75-7e5de2394ba0
 ENV REACT_APP_AUTH_TENANT=3aa4a235-b6e2-48d5-9195-7fcf05b459b0
 ENV REACT_APP_TOKEN_ENDPOINT=https://login.microsoftonline.com/${REACT_APP_AUTH_TENANT}/oauth2/v2.0/token
 ENV REACT_APP_AUTH_ENDPOINT=https://login.microsoftonline.com/${REACT_APP_AUTH_TENANT}/oauth2/v2.0/authorize
 ENV REACT_APP_LOGOUT_ENDPOINT=https://login.microsoftonline.com/${REACT_APP_AUTH_TENANT}/oauth2/logout
-ENV REACT_APP_AUTH_REDIRECT_URI=http://localhost
-ENV REACT_APP_AUTH_SCOPE=https://graph.microsoft.com/User.Read
+ENV REACT_APP_AUTH_REDIRECT_URI=$REDIRECT_URI
+ENV REACT_APP_AUTH_SCOPE=$AUTH_SCOPE
 
 WORKDIR /code/
 COPY jest.config.base.js package.json yarn.lock jest.config.js tsconfig.json ./


### PR DESCRIPTION
## What does this pull request change?
- Adds a global CLI parameter "token"

## Why is this pull request needed?
- Import data to an auth enabled DMSS

## Issues related to this change:
closes #911 