### PR TITLE
Remote run fix

### DIFF
--- a/sre-wrapper/job_wrapper.py
+++ b/sre-wrapper/job_wrapper.py
@@ -132,10 +132,15 @@ def run(
     # Create the commands file (test data: task=WorkflowTask workflow: wave_180 & wave_90
     os.makedirs(settings.WORKSPACE_DIR, exist_ok=True)
     with open(f"{settings.WORKSPACE_DIR}/commands.txt", "w") as commands_file:
-        run_cmd = 'remote-run distributed=false recursive=true' if remote_run else 'run'
+        run_cmd = 'remote-run' if remote_run else 'run'
+        run_cmd_kwargs = f"task={task} workflow={workflow} "  # generic to both run_cmd "run" and "remote-run"
+        if remote_run:  # specific arguments for remote-run
+            run_cmd_kwargs += f"distributed=false recursive=true config={settings.SRE_HOME}/compute.yml "
+            run_cmd_kwargs += f"computeService=scs wait=true download=true"
         commands_file.write(
             f"import file={settings.SRS_HOME}/workflow.stask\n" +
-            f"{run_cmd} task={task} workflow={workflow}\n"
+            f"save\n" +
+            f"{run_cmd} {run_cmd_kwargs} \n"
         )
     with open(f"{settings.WORKSPACE_DIR}/commands.txt", "r") as commands_file:
         print("Wrote stask command file:\n")


### PR DESCRIPTION
## What does this pull request change?

1. It corrects the init.sh as the executable is called sre not sima in the latest images 
2. It corrects the "remote-run" commands.txt file to work with remote-run
3. It creates an autogenerated compute.yml as an alternative to uploading a file. Feature assumes environment variables can be set in the azure container instance at runtime, such as the SCS_PASSWORD which is used to set the password for the compute service. This feature is only a suggestion.

## Why is this pull request needed?

Changes 1 and 2 are needed to run  Change 3 is not needed, but could be nice. 

## Issues related to this change:

## Checklist

- [ ] Your code builds clean without any errors or warnings (NOT TESTED)
- [ ] You are using approved terminology
- [ ] You have added types and interfaces where possible
- [ ] You have added tests
- [ ] You have updated documentation
- [ ] You use defined architecture principles and project structures
- [ ] You are happy with the code quality
