### PR TITLE
edit input before submitting a run

### DIFF
--- a/api/src/home/workflow/job_handlers/reverse_description/__init__.py
+++ b/api/src/home/workflow/job_handlers/reverse_description/__init__.py
@@ -42,7 +42,8 @@ class JobHandler(JobHandlerInterface):
         output_data_source, output_directory = self.job_entity["outputTarget"].split("/", 1)
         input = self._get_by_id(f"{output_data_source}/{self.job_entity['input']['_id']}")
         result = input
-        result["description"] = input.get("description", "")[::-1]
+        result["description"] = input.get("description", "")
+        result["description"].reversed()
         result["name"] = (
             f"reverse-description-job-result-{datetime.now()}".replace(".", "_").replace(":", "_").replace(" ", "_")
         )

--- a/web/packages/plugins/apps/analysis-platform/src/components/CustomScrim.tsx
+++ b/web/packages/plugins/apps/analysis-platform/src/components/CustomScrim.tsx
@@ -1,6 +1,6 @@
 import { Dialog, Icon, Scrim } from '@equinor/eds-core-react'
 import { ClickableIcon } from './Layout/Header'
-import React, { ReactChildren } from 'react'
+import React from 'react'
 
 export const CustomScrim = (props: {
   closeScrim: Function
@@ -10,7 +10,7 @@ export const CustomScrim = (props: {
 }) => {
   const { closeScrim, children, header, width } = props
   return (
-    <Scrim isDismissable onClose={closeScrim}>
+    <Scrim isDismissable onClose={closeScrim} style={{ zIndex: '3' }}>
       <Dialog style={{ width: width ? width : '100%' }}>
         <div
           style={{
@@ -30,7 +30,16 @@ export const CustomScrim = (props: {
             <Icon name="close" size={24} title="Close" />
           </ClickableIcon>
         </div>
-        <div style={{ padding: '20px 30px 30px 30px' }}>{children}</div>
+        <div
+          style={{
+            padding: '20px 30px 30px 30px',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+          }}
+        >
+          {children}
+        </div>
       </Dialog>
     </Scrim>
   )

--- a/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/AnalysisView.tsx
+++ b/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/AnalysisView.tsx
@@ -16,6 +16,11 @@ export default (): JSX.Element => {
   // @ts-ignore
   const { token } = useContext(AuthContext)
 
+  function addJob(newJob: any) {
+    // TODO:
+    console.log('New job added to state')
+  }
+
   const handleTypeSelected = (type: string) => {
     const dmtAPI = new DmtAPI()
     dmtAPI
@@ -33,7 +38,7 @@ export default (): JSX.Element => {
   if (isLoading) return <Progress.Linear />
   return (
     <>
-      <AnalysisInfoCard analysis={analysis} />
+      <AnalysisInfoCard analysis={analysis} addJob={addJob} />
       {'task' in analysis && Object.keys(analysis.task).length ? (
         <>
           <UIPluginSelector

--- a/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/components/AnalysisChooser.tsx
+++ b/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/components/AnalysisChooser.tsx
@@ -5,7 +5,7 @@ import { Heading } from '../../../components/Design/Fonts'
 import React from 'react'
 import { TTask } from '../Types'
 import { useSearch } from '@dmt/common'
-import { DEFAULT_DATASOURCE_ID, WORKFLOW_DATASOURCE } from '../../../const'
+import { WORKFLOW_DATASOURCE } from '../../../const'
 
 type TaskTypeProps = {
   task: TTask

--- a/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/components/AnalysisInfo.tsx
+++ b/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/components/AnalysisInfo.tsx
@@ -13,10 +13,11 @@ const OnRight = styled.div`
 
 type AnalysisInfoCardProps = {
   analysis: TAnalysis
+  addJob: Function
 }
 
 const AnalysisInfoCard = (props: AnalysisInfoCardProps) => {
-  const { analysis } = props
+  const { analysis, addJob } = props
   const [isEditing, setIsEditing] = useState<boolean>(false)
 
   const handleSubmitTask = (task: TTask) => {
@@ -35,7 +36,7 @@ const AnalysisInfoCard = (props: AnalysisInfoCardProps) => {
         </OnRight>
       ) : (
         <OnRight>
-          <AnalysisCard analysis={analysis} />
+          <AnalysisCard analysis={analysis} addJob={addJob} />
           <Button onClick={() => setIsEditing(true)} variant="ghost_icon">
             <Icons name="edit_text" title="edit_text" />
           </Button>

--- a/web/packages/plugins/shared/common/src/components/UiPluginSelector.tsx
+++ b/web/packages/plugins/shared/common/src/components/UiPluginSelector.tsx
@@ -1,5 +1,10 @@
-import React, { useContext, useEffect, useState } from 'react'
-import { UiPluginContext, useBlueprint } from '@dmt/common'
+import React, {
+  useContext,
+  useEffect,
+  useState,
+  FunctionComponent,
+} from 'react'
+import { DmtUIPlugin, UiPluginContext, useBlueprint } from '@dmt/common'
 import styled from 'styled-components'
 import { DotProgress } from '@equinor/eds-core-react'
 
@@ -22,6 +27,14 @@ const PathWrapper = styled.div`
   display: flex;
   opacity: 60%;
   justify-content: center;
+  font-size: 14px;
+  height: 20px;
+  overflow: hidden;
+`
+
+const PathPart = styled.div`
+  margin-top: 0;
+  margin-right: 15px;
 `
 
 export function DocumentPath(props: { absoluteDottedId: string }): JSX.Element {
@@ -31,8 +44,9 @@ export function DocumentPath(props: { absoluteDottedId: string }): JSX.Element {
     <PathWrapper>
       {parts.map((part: string) => {
         return (
-          <div style={{ display: 'flex' }} key={part}>
-            <div style={{ margin: '0 15px' }}>/</div> {part}
+          <div style={{ display: 'flex', flexWrap: 'nowrap' }} key={part}>
+            <PathPart>/</PathPart>
+            <PathPart>{part}</PathPart>
           </div>
         )
       })}
@@ -60,8 +74,9 @@ const SelectPluginButton = styled.div<ISPButton>`
 export function UIPluginSelector(props: {
   absoluteDottedId: string
   entity: any
+  onSubmit?: Function
 }): JSX.Element {
-  const { absoluteDottedId, entity } = props
+  const { absoluteDottedId, entity, onSubmit } = props
   const [dataSourceId, documentId] = absoluteDottedId.split('/', 2)
   const [blueprint, loadingBlueprint, error] = useBlueprint(entity.type)
   // @ts-ignore
@@ -94,7 +109,9 @@ export function UIPluginSelector(props: {
       </div>
     )
 
-  const UiPlugin = selectablePluginsComponent[selectedPlugin][1]
+  const UiPlugin: FunctionComponent<DmtUIPlugin> = selectablePluginsComponent[
+    selectedPlugin
+  ][1] as FunctionComponent
 
   return (
     <Wrapper>
@@ -116,6 +133,7 @@ export function UIPluginSelector(props: {
         dataSourceId={dataSourceId}
         documentId={documentId}
         document={entity}
+        onSubmit={onSubmit}
       />
     </Wrapper>
   )

--- a/web/packages/plugins/shared/common/src/context/UiPluginContext.tsx
+++ b/web/packages/plugins/shared/common/src/context/UiPluginContext.tsx
@@ -15,15 +15,15 @@ export interface LoadedPlugin {
 }
 
 export interface DmtUIPlugin {
-  type: string
+  type?: string
   dataSourceId: string
   documentId: string
-  explorer: any
-  uiRecipeName: any
-  useIndex: any
-  onSubmit: any
-  document: any
-  updateDocument: any
+  explorer?: any
+  uiRecipeName?: any
+  useIndex?: Function
+  onSubmit?: Function
+  document?: any
+  updateDocument?: any
 }
 
 export enum DmtPluginType {

--- a/web/packages/plugins/ui/sima-task/src/EditReverseTask.tsx
+++ b/web/packages/plugins/ui/sima-task/src/EditReverseTask.tsx
@@ -2,17 +2,13 @@ import {
   BlueprintPicker,
   DmtUIPlugin,
   EntityPicker,
-  EntityPickerDropdown,
   TReference,
-  UploadFileButton,
   useDocument,
 } from '@dmt/common'
 import * as React from 'react'
-import { ChangeEvent, useState } from 'react'
-import { Button, Label, TextField, Typography } from '@equinor/eds-core-react'
+import { useState } from 'react'
+import { Button, Label, Typography } from '@equinor/eds-core-react'
 import styled from 'styled-components'
-
-const STaskBlueprint = 'AnalysisPlatformDS/Blueprints/STask'
 
 const Wrapper = styled.div`
   margin: 10px;
@@ -22,9 +18,6 @@ const Column = styled.div`
   display: block;
 `
 
-const Row = styled.div`
-  display: flex;
-`
 const GroupWrapper = styled.div`
   display: flex;
   justify-content: space-between;
@@ -37,7 +30,7 @@ const HeaderWrapper = styled.div`
 `
 
 export const EditReverseTask = (props: DmtUIPlugin) => {
-  const { document, documentId, dataSourceId } = props
+  const { document, documentId, dataSourceId, onSubmit } = props
   // using the passed updateDocument from props causes way too much rerendering. This should probably be fixed...
   const [_document, documentLoading, updateDocument, error] = useDocument(
     dataSourceId,
@@ -102,7 +95,16 @@ export const EditReverseTask = (props: DmtUIPlugin) => {
             >
               Reset
             </Button>
-            <Button as="button" onClick={() => updateDocument(formData, true)}>
+            <Button
+              as="button"
+              onClick={() => {
+                if (onSubmit) {
+                  onSubmit(formData)
+                } else {
+                  updateDocument(formData, true)
+                }
+              }}
+            >
               Ok
             </Button>
           </div>

--- a/web/packages/plugins/ui/sima-task/src/EditSimaTask.tsx
+++ b/web/packages/plugins/ui/sima-task/src/EditSimaTask.tsx
@@ -8,7 +8,7 @@ import {
   useDocument,
 } from '@dmt/common'
 import * as React from 'react'
-import { ChangeEvent, useState } from 'react'
+import { ChangeEvent, useEffect, useState } from 'react'
 import { Button, Label, TextField, Typography } from '@equinor/eds-core-react'
 import styled from 'styled-components'
 
@@ -43,7 +43,12 @@ export const EditSimaTask = (props: DmtUIPlugin) => {
     dataSourceId,
     documentId
   )
-  const [formData, setFormData] = useState<any>({ ...document })
+  const [formData, setFormData] = useState<any>({})
+
+  useEffect(() => {
+    if (!_document) return
+    setFormData({ ..._document })
+  }, [_document])
 
   function getNewSTaskBody(filename: string): any {
     return {

--- a/web/packages/plugins/ui/sima-task/src/EditSimaTask.tsx
+++ b/web/packages/plugins/ui/sima-task/src/EditSimaTask.tsx
@@ -37,7 +37,7 @@ const HeaderWrapper = styled.div`
 `
 
 export const EditSimaTask = (props: DmtUIPlugin) => {
-  const { document, documentId, dataSourceId } = props
+  const { document, documentId, dataSourceId, onSubmit } = props
   // using the passed updateDocument from props causes way too much rerendering. This should probably be fixed...
   const [_document, documentLoading, updateDocument, error] = useDocument(
     dataSourceId,
@@ -194,7 +194,16 @@ export const EditSimaTask = (props: DmtUIPlugin) => {
             >
               Reset
             </Button>
-            <Button as="button" onClick={() => updateDocument(formData, true)}>
+            <Button
+              as="button"
+              onClick={() => {
+                if (onSubmit) {
+                  onSubmit(formData)
+                } else {
+                  updateDocument(formData, true)
+                }
+              }}
+            >
               Ok
             </Button>
           </div>

--- a/web/packages/plugins/ui/yaml-view/src/index.tsx
+++ b/web/packages/plugins/ui/yaml-view/src/index.tsx
@@ -1,11 +1,16 @@
 import * as React from 'react'
 
 import './index.css'
-import { DmtPluginType, DmtUIPlugin } from '@dmt/common'
+import { DmtPluginType, DmtUIPlugin, useDocument } from '@dmt/common'
 import PreviewPlugin from './YamlPlugin'
 
 const PluginComponent = (props: DmtUIPlugin) => {
-  const { document } = props
+  const { documentId, dataSourceId } = props
+  const [document, documentLoading, updateDocument, error] = useDocument(
+    dataSourceId,
+    documentId
+  )
+  if (documentLoading) return <div>Loading...</div>
   return <PreviewPlugin document={document} />
 }
 


### PR DESCRIPTION
## What does this pull request change?

- Clicking "Run job" opens a modal with uiPLugins for the task that can be eddited. Clicking submit starts a job with the edited task as parameters.
- Yaml-view always fetches the latest document when rendered, to any changes made can be seen without refreshing

![Screenshot_20220222_091508](https://user-images.githubusercontent.com/11062560/155090417-0c8ee08b-312a-4160-9122-1daf3b881dd6.png)

## Why is this pull request needed?
User should be able to edit parameters on a per run basis


## Issues related to this change:
closes #1031 
