### PR TITLE
Remove explorer as input to UI plugins

### DIFF
--- a/web/packages/plugins/apps/dmt-app/src/pages/editor/layout-components/DocumentComponent.tsx
+++ b/web/packages/plugins/apps/dmt-app/src/pages/editor/layout-components/DocumentComponent.tsx
@@ -50,7 +50,6 @@ const View = (props: any) => {
     <UiPlugin
       dataSourceId={dataSourceId}
       documentId={documentId}
-      explorer={explorer}
       uiRecipe={uiRecipe}
       uiRecipeName={uiRecipe.name}
       updateDocument={onSubmit}

--- a/web/packages/plugins/shared/common/src/context/UiPluginContext.tsx
+++ b/web/packages/plugins/shared/common/src/context/UiPluginContext.tsx
@@ -18,7 +18,6 @@ export interface DmtUIPlugin {
   type?: string
   dataSourceId: string
   documentId: string
-  explorer?: any
   uiRecipeName?: any
   useIndex?: Function
   onSubmit?: Function

--- a/web/packages/plugins/ui/default-form/src/BlueprintSchema.ts
+++ b/web/packages/plugins/ui/default-form/src/BlueprintSchema.ts
@@ -345,7 +345,10 @@ export class BlueprintSchema implements IBlueprintSchema {
       return true
     } else if (Array.isArray(document[attributeName])) {
       return true
-    } else if (Object.keys(document[attributeName]).length === 0) {
+    } else if (
+      attributeName in document &&
+      Object.keys(document[attributeName]).length === 0
+    ) {
       return false
     } else {
       return true

--- a/web/packages/plugins/ui/default-form/src/index.tsx
+++ b/web/packages/plugins/ui/default-form/src/index.tsx
@@ -16,14 +16,24 @@ import {
   BlueprintPicker,
   DestinationPicker,
   AuthContext,
+  DmssAPI,
 } from '@dmt/common'
 
+function useExplorer(dmssAPI: DmssAPI) {
+  const getBlueprint = (typeRef: string) => dmssAPI.getBlueprint({ typeRef })
+  return {
+    getBlueprint,
+  }
+}
+
 const PluginComponent = (props: DmtUIPlugin) => {
-  const { document, uiRecipeName, explorer, onSubmit } = props
+  const { document, uiRecipeName, onSubmit } = props
   const [config, setConfig] = useState(undefined)
   const [error, setError] = useState<string | null>(null)
   // @ts-ignore-line
   const { token } = useContext(AuthContext)
+  const dmssAPI = new DmssAPI(token)
+  const explorer = useExplorer(dmssAPI)
 
   useEffect(() => {
     createFormConfigs({
@@ -36,6 +46,7 @@ const PluginComponent = (props: DmtUIPlugin) => {
       .then((config: FormConfig) => setConfig(config))
       .catch((error) => {
         setError(error.message)
+        console.log(error.stack)
         throw `error occured when creating config for default-form:  ${error}`
       })
   }, [])

--- a/web/packages/plugins/ui/mermaid/src/index.tsx
+++ b/web/packages/plugins/ui/mermaid/src/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useContext, useEffect, useState } from 'react'
 
-import { AuthContext, DmtPluginType, DmtUIPlugin } from '@dmt/common'
+import { AuthContext, DmssAPI, DmtPluginType, DmtUIPlugin } from '@dmt/common'
 import Mermaid from './Mermaid'
 import { dfs, loader, Node } from './loader'
 import { AttributeType } from './types'
@@ -58,11 +58,20 @@ const createChart = (tree: Node): string => {
   return chart
 }
 
+function useExplorer(dmssAPI: DmssAPI) {
+  const getBlueprint = (typeRef: string) => dmssAPI.getBlueprint({ typeRef })
+  return {
+    getBlueprint,
+  }
+}
+
 const PluginComponent = (props: DmtUIPlugin) => {
-  const { document, explorer } = props
+  const { document } = props
 
   // @ts-ignore
   const { token } = useContext(AuthContext)
+  const dmssAPI = new DmssAPI(token)
+  const explorer = useExplorer(dmssAPI)
 
   const [chart, setChart] = useState<string | undefined>(undefined)
 


### PR DESCRIPTION
## What does this pull request change?

* Explorer is removed as an input to UI plugins

## Why is this pull request needed?

* Explorer is a dependency that should not be input to UI plugins. It was only used for getting blueprints inside UI plugins, but this can be done by calling the DMSS API directly instead. 

## Issues related to this change:

## Checklist

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added types and interfaces where possible
- [ ] You have added tests
- [ ] You have updated documentation
- [ ] You use defined architecture principles and project structures
- [ ] You are happy with the code quality

#1043 