### PR TITLE
run local container job

### DIFF
--- a/api/src/home/analysis-platform/data/AnalysisPlatformDS/Data/Analysis/exampleReverseAnalysis.json
+++ b/api/src/home/analysis-platform/data/AnalysisPlatformDS/Data/Analysis/exampleReverseAnalysis.json
@@ -1,7 +1,7 @@
 {
-  "_id": "4483c9b0-d505-46c9-a157-94c79f4d7a6b",
+  "_id": "4483c9b0-d505-46c9-a157-94c79f4d7a6c",
   "type": "AnalysisPlatformDS/Blueprints/Analysis",
-  "name": "jghjhg",
+  "name": "exampleReverseAnalysis",
   "description": "",
   "creator": "STOO",
   "created": "2022-03-02T14:15:59.601Z",

--- a/api/src/home/workflow/data/WorkflowDS/Blueprints/jobHandlers/Container.json
+++ b/api/src/home/workflow/data/WorkflowDS/Blueprints/jobHandlers/Container.json
@@ -4,6 +4,7 @@
   "description": "A container job",
   "extends": [
     "system/SIMOS/DefaultUiRecipes",
+    "system/SIMOS/NamedEntity",
     "/jobHandlers/JobHandler"
   ],
   "attributes": [
@@ -17,6 +18,20 @@
       "attributeType": "string",
       "type": "system/SIMOS/BlueprintAttribute",
       "name": "image"
+    },
+    {
+      "attributeType": "string",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "name": "command"
+    }
+  ],
+  "uiRecipes": [
+    {
+      "name": "EditContainer",
+      "type": "system/SIMOS/UiRecipe",
+      "plugin": "edit-local-container-job",
+      "configType": "",
+      "category": "edit"
     }
   ]
 }

--- a/api/src/home/workflow/job_handlers/local_container/__init__.py
+++ b/api/src/home/workflow/job_handlers/local_container/__init__.py
@@ -1,0 +1,111 @@
+import docker
+from docker.errors import DockerException
+from typing import Tuple, Optional
+from services.job_handler_interface import JobHandlerInterface, JobStatus
+from utils.logging import logger
+from uuid import uuid4
+from dmss_api.apis import DefaultApi
+import json
+
+import os
+_SUPPORTED_TYPE = "WorkflowDS/Blueprints/jobHandlers/Container"
+
+# class JobEntity(BaseModel):
+#     name: str
+#     image: str
+#     command: Optional[str]
+
+
+class Settings():
+    PUBLIC_DMSS_API: str = os.getenv("PUBLIC_DMSS_API", "http://dmss:5000") #tood port 8000?
+
+
+
+dmss_api = DefaultApi()
+settings = Settings()
+dmss_api.api_client.configuration.host = settings.PUBLIC_DMSS_API
+
+class JobHandler(JobHandlerInterface):
+    """
+    A job handler to run local docker container. This is similar to the local_containers job handler in DMT, but uses
+    a different blueprint
+    """
+
+    def __init__(self, data_source: str, job_entity: dict, token: str, insert_reference: callable):
+        super().__init__(data_source, job_entity, token, insert_reference)
+        self.headers = {"Access-Key": token}
+        try:
+            self.client = docker.from_env()
+        except DockerException:
+            raise DockerException(
+                (
+                    "Failed to get a docker client. Docker must be installed on this host, or "
+                    + "the /var/run/docker.sock must be made available (volume mount)."
+                    + "Make sure you are aware of the serious security risk this entails."
+                )
+            )
+
+    def start(self) -> str:
+        try:
+            runnerEntity: dict = self.job_entity["runner"]
+            logger.info(
+                f"JobName: '{self.job_entity.get('_id', self.job_entity.get('name'))}'."
+                + " Starting Local Container job..."
+            )
+            logger.info(f"job_entity is {self.job_entity}")
+
+            logger.info(
+                "Creating container\n\t"
+                + f"Image: '{runnerEntity['image']}'\n\t"
+                + f"Command: {runnerEntity.get('command', 'None')}"
+            )
+
+
+            self.client.containers.run(
+                image=runnerEntity["image"],
+                command=[runnerEntity["command"]] + [f"--token={self.token}"],
+                name="someName_"+str(uuid4()),
+                # environment=env_vars,
+                network="data-modelling-storage-service_default", #??
+                detach=True,
+            )
+
+            #generate a result dict and uplo
+
+
+            result_id = str(uuid4())
+            example_result: dict = {
+                "uid": result_id,
+                "type": "system/SIMOS/NamedEntity",
+                "name": f"resultFromLocalContainer_{result_id}",
+                "description": "Example result from running a local container job"
+            }
+            dmss_api.api_client.default_headers["Authorization"] = "Bearer " + self.token
+            data_source, directory = self.job_entity["outputTarget"].split("/", 1)
+            logger.info(f"*** ds is {data_source} and directory is {directory}")
+            response = dmss_api.explorer_add_to_path(document=json.dumps(example_result), directory=directory, data_source_id=data_source)
+            print(f"Result with is {response['uid']} was uploaded to {directory} ")
+
+            RESULT_FILE_TYPE = f"{data_source}/FoR-BP/Blueprints/ResultFile"
+            reference_object = {"name": f"resultFromLocalContainer_{result_id}", "id": response['uid'], "type": "system/SIMOS/NamedEntity"}
+            response = dmss_api.reference_insert(data_source_id=data_source, document_dotted_id=runnerEntity["resultLinkTarget"], reference=reference_object)
+            logger.info(f"reference to result was added to the analysis ({runnerEntity['resultLinkTarget']})")
+
+        except KeyError as error:
+            raise Exception(f"Job entity used as input to local container jobs does not include required attribute {error}")
+
+
+        logger.info("Local container job completed")
+        return "Ok"
+
+
+    def remove(self) -> str:
+        container = self.client.containers.get(self.job_entity["name"])
+        container.remove()
+        return JobStatus.UNKNOWN, "Removed"
+
+    def progress(self) -> Tuple[JobStatus, str]:
+        """Poll progress from the job instance"""
+        container = self.client.containers.get(self.job_entity["name"])
+        logs = container.logs()
+        return JobStatus.UNKNOWN, logs.decode()

--- a/api/src/home/workflow/job_handlers/reverse_description/__init__.py
+++ b/api/src/home/workflow/job_handlers/reverse_description/__init__.py
@@ -62,4 +62,4 @@ class JobHandler(JobHandlerInterface):
 
     def progress(self) -> Tuple[JobStatus, str]:
         """Poll progress from the job instance"""
-        return JobStatus.UNKNOWN, "This job type does not support progress polling"
+        return JobStatus.UNKNOWN, "ReverseDescription job type does not support progress polling"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -13,7 +13,7 @@ services:
     image: api-dev
     volumes:
       - ./api/src/:/code
-#      - /var/run/docker.sock:/var/run/docker.sock  # Needed for docker-in-docker jobs
+      - /var/run/docker.sock:/var/run/docker.sock  # Needed for docker-in-docker jobs
 #      - ../data-modelling-storage-service/gen/dmss_api:/dmss_api
 #      - ../data-modelling-storage-service:/data-modelling-storage-service
     environment:
@@ -66,8 +66,8 @@ services:
   job-store:
     image: redis:6.2.5-alpine
     command: "redis-server --save 30 1 --loglevel notice"
-    #volumes:
-    # - ./redis_data:/data
+    volumes:
+     - ./redis_data:/data
     networks:
       - data-modelling-storage-service_default
 

--- a/web/packages/plugins/apps/analysis-platform/src/Types.ts
+++ b/web/packages/plugins/apps/analysis-platform/src/Types.ts
@@ -39,3 +39,35 @@ export type TJob = {
   subnetId?: string
   logAnalyticsWorkspaceResourceId?: string
 }
+
+export type TTask = {
+  type: string
+  description: string
+  label: string
+  inputType: string
+  input: any
+  outputType: string
+  runner: { type: string }
+}
+
+export type TTtestJob = {
+  type: string
+  triggeredBy: string
+  outputTarget: string
+  input: any
+  runner: { type: string }
+  label?: string
+  resultLinkTarget: string
+  // image: string
+  // command: string
+  // environmentVariables?: string[]
+}
+
+export type TLocalContainerJob = {
+  type: string
+  name: string
+  label?: string
+  image: string
+  command: string
+  environmentVariables?: string[]
+}

--- a/web/packages/plugins/apps/analysis-platform/src/const.ts
+++ b/web/packages/plugins/apps/analysis-platform/src/const.ts
@@ -1,8 +1,10 @@
 export const DEFAULT_DATASOURCE_ID = 'AnalysisPlatformDS'
 export const WORKFLOW_DATASOURCE = 'WorkflowDS'
 export const JOB = `${WORKFLOW_DATASOURCE}/Blueprints/Job`
+export const LOCAL_CONTAINER_JOB_HANDLER = `${WORKFLOW_DATASOURCE}/Blueprints/jobHandlers/Container`
 export const JOB_HANDLER = `${WORKFLOW_DATASOURCE}/Blueprints/jobHandlers/JobHandler`
 export const BLUEPRINTS = 'Blueprints'
 export const ENTITIES = 'Data'
 export const ANALYSIS_PATH = `${ENTITIES}/Analysis`
+export const ANALYSIS_RESULTS_PATH = `${DEFAULT_DATASOURCE_ID}/${ANALYSIS_PATH}/results`
 export const TASK = 'WorkflowDS/Blueprints/Task'

--- a/web/packages/plugins/ui/job-handlers/src/EditLocalContainer.tsx
+++ b/web/packages/plugins/ui/job-handlers/src/EditLocalContainer.tsx
@@ -1,0 +1,84 @@
+import { DmtUIPlugin } from '@dmt/common'
+import * as React from 'react'
+import { ChangeEvent, useState } from 'react'
+import {
+  Button,
+  SingleSelect,
+  TextField,
+  Typography,
+} from '@equinor/eds-core-react'
+import styled from 'styled-components'
+
+const Wrapper = styled.div`
+  margin: 10px;
+`
+
+const HeaderWrapper = styled.div`
+  margin-bottom: 20px;
+`
+
+export const EditLocalContainer = (props: DmtUIPlugin) => {
+  const { document, documentId, dataSourceId, onSubmit } = props
+  const [formData, setFormData] = useState<any>({ ...document })
+
+  return (
+    <div
+      style={{ display: 'flex', alignItems: 'center', flexDirection: 'column' }}
+    >
+      <div
+        style={{
+          maxWidth: '900px',
+          width: '100%',
+          marginBottom: '10px',
+          width: '-webkit-fill-available',
+        }}
+      >
+        <Wrapper>
+          <HeaderWrapper style={{ width: '70%' }}>
+            <Typography variant="h5">Container image</Typography>
+            <SingleSelect
+              id="image"
+              label={'Container image'}
+              // value={formData.crUsername}
+              placeholder="Image to run"
+              items={['alpine']}
+              handleSelectedItemChange={selected =>
+                setFormData({ ...formData, image: selected.inputValue })
+              }
+              // onChange={(event: ChangeEvent<HTMLInputElement>) =>
+              //   setFormData({ ...formData, image: event.target.value })
+              // }
+            />
+          </HeaderWrapper>
+          <HeaderWrapper style={{ width: '70%' }}>
+            <Typography variant="h5">Command</Typography>
+            <SingleSelect
+              id="command"
+              label={'Command to run'}
+              // value={formData.crUsername}
+              placeholder="Command for the container (parameters)"
+              items={['ls', 'echo 123']}
+              handleSelectedItemChange={selected =>
+                setFormData({ ...formData, command: selected.inputValue })
+              }
+            />
+          </HeaderWrapper>
+
+          <div style={{ justifyContent: 'space-around', display: 'flex' }}>
+            <Button
+              as="button"
+              variant="outlined"
+              color="danger"
+              onClick={() => setFormData({ ...document })}
+            >
+              Reset
+            </Button>
+            <Button as="button" onClick={() => onSubmit(formData)}>
+              Ok
+            </Button>
+          </div>
+        </Wrapper>
+      </div>
+    </div>
+  )
+}

--- a/web/packages/plugins/ui/job-handlers/src/index.tsx
+++ b/web/packages/plugins/ui/job-handlers/src/index.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 
 import { DmtPluginType } from '@dmt/common'
 import { EditAzureContainer } from './EditAzureContainer'
+import { EditLocalContainer } from './EditLocalContainer'
 
 export const plugins: any = [
   {
@@ -9,6 +10,13 @@ export const plugins: any = [
     pluginType: DmtPluginType.UI,
     content: {
       component: EditAzureContainer,
+    },
+  },
+  {
+    pluginName: 'edit-local-container-job',
+    pluginType: DmtPluginType.UI,
+    content: {
+      component: EditLocalContainer,
     },
   },
 ]


### PR DESCRIPTION
## What does this pull request change?

## Why is this pull request needed?

## Issues related to this change:

## Checklist

# notes 
lage input entity type (sima input greie i figma fra babak
job runner azure container:
	- i edit tab, sett default verdier på ting foreløbig.
	

job greien tar imot task.

må sende inn stask eksempel - 



første steg: start opp en container med random json input.
bruk local container jobs til å ta inn ny job handler (local container)	
	
	
--------------------
when clicking  "Run analysis", a job is created (type /Blueprints/Job) is added to the entity and the job api is used to start the newly created job.

A job has specified a job runner that defines what will run the job (eg a container)


--- job api
exists in the DMT repo in the job controller.

a job can be started with the api/job endpoint.
this will register a job in the job_service.py, and also start the job
using the job_handler.

The job_handler is different based on the type of job: can be azure conatiner, local container,etc (see dmt src/services/job_handlers folder)

-> i must probably create a new job_handler to run the workfolwDS/Blueprints/jobHandlers/Container type job.


