### PR TITLE
show jobs in table

### DIFF
--- a/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/AnalysisView.tsx
+++ b/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/AnalysisView.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { AuthContext, UIPluginSelector, useDocument } from '@dmt/common'
 import { Progress } from '@equinor/eds-core-react'
@@ -12,25 +12,29 @@ export default (): JSX.Element => {
     data_source,
     entity_id
   )
-  // @ts-ignore
-  const { token } = useContext(AuthContext)
+  const [jobs, setJobs] = useState<any[]>([])
+
+  useEffect(() => {
+    if (!analysis) return
+    setJobs(analysis.jobs)
+  }, [analysis])
 
   function addJob(newJob: any) {
-    // TODO:
+    setJobs([...jobs, newJob])
     console.log('New job added to state')
   }
 
   if (isLoading) return <Progress.Linear />
   return (
     <>
-      <AnalysisInfoCard analysis={analysis} addJob={addJob} />
+      <AnalysisInfoCard analysis={analysis} addJob={addJob} jobs={jobs} />
       <>
         <UIPluginSelector
           entity={analysis.task}
           absoluteDottedId={`${data_source}/${analysis._id}.task`}
           categories={['container', 'view']}
         />
-        <AnalysisJobTable analysis={analysis} />
+        <AnalysisJobTable jobs={jobs} analysisId={analysis._id} />
       </>
     </>
   )

--- a/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/components/AnalysisCard.tsx
+++ b/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/components/AnalysisCard.tsx
@@ -42,14 +42,12 @@ const CardWrapper = styled.div`
 type AnalysisCardProps = {
   analysis: TAnalysis
   addJob: Function
+  jobs: any
 }
 
 const RunAnalysisButton = (props: any) => {
-  const { analysis, addJob } = props
-  // TODO: setJobs should be a passed prop
-  const [jobs, setJobs] = useState<any[]>([...analysis.jobs])
+  const { analysis, addJob, jobs } = props
   const [showScrim, setShowScrim] = useState<boolean>(false)
-
   const [loading, setLoading] = useState<boolean>(false)
   const { token, tokenData } = useContext(AuthContext)
   const dmssAPI = new DmssAPI(token)
@@ -64,6 +62,7 @@ const RunAnalysisButton = (props: any) => {
       name: `${analysis.task.name}-${poorMansUUID()}`,
       triggeredBy: tokenData?.name,
       type: JOB,
+      started: new Date(),
       outputTarget: analysis.task.outputTarget,
       input: analysis.task.input,
       runner: analysis.task.runner,
@@ -76,7 +75,6 @@ const RunAnalysisButton = (props: any) => {
       })
       .then(() => {
         // Add the new job to the state
-        setJobs([...jobs, job])
         // Start a job from the created job entity (last one in list)
         jobAPI
           .startJob(`${analysisAbsoluteReference}.jobs.${runsSoFar}`)
@@ -141,7 +139,7 @@ const RunAnalysisButton = (props: any) => {
 }
 
 const AnalysisCard = (props: AnalysisCardProps) => {
-  const { analysis, addJob } = props
+  const { analysis, addJob, jobs } = props
   const [viewACL, setViewACL] = useState<boolean>(false)
   // @ts-ignore
   const { tokenData } = useContext(AuthContext)
@@ -194,7 +192,11 @@ const AnalysisCard = (props: AnalysisCardProps) => {
           )}
           {'task' in analysis && Object.keys(analysis.task).length > 0 && (
             <>
-              <RunAnalysisButton analysis={analysis} addJob={addJob} />
+              <RunAnalysisButton
+                analysis={analysis}
+                addJob={addJob}
+                jobs={jobs}
+              />
               <Tooltip title={'Not implemented'}>
                 <Button style={{ width: 'max-content' }} disabled>
                   Configure schedule

--- a/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/components/AnalysisInfo.tsx
+++ b/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/components/AnalysisInfo.tsx
@@ -5,6 +5,7 @@ import { TAnalysis, TTask } from '../Types'
 import styled from 'styled-components'
 import CreateAnalysisForm from './CreateAnalysisForm'
 import AnalysisCard from './AnalysisCard'
+import analysisJobTable from './AnalysisJobTable'
 
 const OnRight = styled.div`
   display: flex;
@@ -14,10 +15,11 @@ const OnRight = styled.div`
 type AnalysisInfoCardProps = {
   analysis: TAnalysis
   addJob: Function
+  jobs: any
 }
 
 const AnalysisInfoCard = (props: AnalysisInfoCardProps) => {
-  const { analysis, addJob } = props
+  const { analysis, addJob, jobs } = props
   const [isEditing, setIsEditing] = useState<boolean>(false)
 
   const handleSubmitTask = (task: TTask) => {
@@ -36,7 +38,7 @@ const AnalysisInfoCard = (props: AnalysisInfoCardProps) => {
         </OnRight>
       ) : (
         <OnRight>
-          <AnalysisCard analysis={analysis} addJob={addJob} />
+          <AnalysisCard analysis={analysis} addJob={addJob} jobs={jobs} />
           <Button onClick={() => setIsEditing(true)} variant="ghost_icon">
             <Icons name="edit_text" title="edit_text" />
           </Button>

--- a/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/components/AnalysisJobTable.tsx
+++ b/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/components/AnalysisJobTable.tsx
@@ -1,13 +1,79 @@
-import { Button, Progress, Table, Typography } from '@equinor/eds-core-react'
-import React, { useContext, useState } from 'react'
-import { TAnalysis } from '../Types'
+import { Table, Typography } from '@equinor/eds-core-react'
+import React, { useContext, useEffect, useState } from 'react'
+import { AuthContext, JobApi } from '@dmt/common'
+import { DEFAULT_DATASOURCE_ID } from '../../../const'
+import styled from 'styled-components'
 
 type AnalysisJobTableProps = {
-  analysis: TAnalysis
+  jobs: any
+  analysisId: string
+}
+
+enum JobStatus {
+  STARTING = 'starting',
+  RUNNING = 'running',
+  FAILED = 'failed',
+  COMPLETED = 'completed',
+  UNKNOWN = 'unknown',
+}
+
+const ClickableLabel = styled.div`
+  cursor: pointer;
+  color: blue;
+  text-decoration-line: underline;
+`
+
+const JobRow = (props: any) => {
+  const { job, index, analysisId } = props // @ts-ignore
+  const { token } = useContext(AuthContext)
+  const JobAPI = new JobApi(token)
+  const [loading, setLoading] = useState<boolean>(false)
+  const [jobStatus, setJobStatus] = useState<JobStatus>(JobStatus.UNKNOWN)
+
+  useEffect(() => {
+    setLoading(true)
+    JobAPI.statusJob(`${DEFAULT_DATASOURCE_ID}/${analysisId}.jobs.${index}`)
+      .then((result: any) => {
+        setJobStatus(result.data.status)
+      })
+      .catch((e: Error) => {
+        console.error(e)
+      })
+      .finally(() => setLoading(false))
+  }, [])
+
+  return (
+    <Table.Row
+      key={index}
+      onClick={() => {
+        document.location = `/ap/view/${DEFAULT_DATASOURCE_ID}/${analysisId}.jobs.${index}`
+      }}
+    >
+      <Table.Cell>
+        {new Date(job.started).toLocaleString(navigator.language)}
+      </Table.Cell>
+      <Table.Cell>{job.triggeredBy}</Table.Cell>
+      <Table.Cell>{}</Table.Cell>
+      <Table.Cell>{jobStatus}</Table.Cell>
+      <Table.Cell>
+        <ClickableLabel
+          onClick={(e) => {
+            window.open(
+              `/ap/view/AnalysisPlatformDS/${job.result?._id}`,
+              '_blank'
+            )
+            e.stopPropagation()
+          }}
+        >
+          Open
+        </ClickableLabel>
+      </Table.Cell>
+    </Table.Row>
+  )
 }
 
 const AnalysisJobTable = (props: AnalysisJobTableProps) => {
-  const { analysis } = props
+  const { jobs, analysisId } = props
 
   return (
     <>
@@ -17,19 +83,22 @@ const AnalysisJobTable = (props: AnalysisJobTableProps) => {
         </Table.Caption>
         <Table.Head>
           <Table.Row>
-            <Table.Cell>Status</Table.Cell>
-            <Table.Cell>Job</Table.Cell>
+            <Table.Cell>Started</Table.Cell>
+            <Table.Cell>Started by</Table.Cell>
             <Table.Cell>Duration</Table.Cell>
+            <Table.Cell>Status</Table.Cell>
             <Table.Cell>Result</Table.Cell>
           </Table.Row>
         </Table.Head>
-        <Table.Body>
-          <Table.Row>
-            <Table.Cell>Success</Table.Cell>
-            <Table.Cell>1</Table.Cell>
-            <Table.Cell>2m 31s</Table.Cell>
-            <Table.Cell>LINK</Table.Cell>
-          </Table.Row>
+        <Table.Body style={{ cursor: 'pointer' }}>
+          {jobs.map((job: any, index: number) => (
+            <JobRow
+              key={index}
+              job={job}
+              index={index}
+              analysisId={analysisId}
+            />
+          ))}
         </Table.Body>
       </Table>
     </>


### PR DESCRIPTION
## What does this pull request change?

Show runned jobs in table instead of hard coded data. 
Still missing duration. To be able to set the duration the end time of the runned job needs to be set. 

## Why is this pull request needed?

## Issues related to this change:

