### PR TITLE
Add support for optional in form UI plugin

### DIFF
--- a/api/src/home/DMT/data/demoDSAlias/DMT-demo/Plugins/Form/FormBlueprint.json
+++ b/api/src/home/DMT/data/demoDSAlias/DMT-demo/Plugins/Form/FormBlueprint.json
@@ -1,6 +1,10 @@
 {
   "name": "FormBlueprint",
   "type": "system/SIMOS/Blueprint",
+  "extends": [
+    "system/SIMOS/DefaultUiRecipes",
+    "system/SIMOS/NamedEntity"
+  ],
   "attributes": [
     {
       "name": "aNumber",
@@ -15,11 +19,38 @@
       "label":  "A string"
     },
     {
+      "name": "aOptionalNumber",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "number",
+      "label":  "A optional number",
+      "optional": true
+    },
+    {
+      "name": "aOptionalString",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "label":  "A optional string",
+      "optional": true
+    },
+    {
       "name": "listOfStrings",
       "type": "system/SIMOS/BlueprintAttribute",
       "attributeType": "string",
       "dimensions": "*",
       "label":  "A list of strings"
+    },
+    {
+      "name": "aNestedObject",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "/Plugins/Form/Nested",
+      "label":  "A nested object"
+    },
+    {
+      "name": "aOptionalNestedObject",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "/Plugins/Form/Nested",
+      "label":  "A optional nested object",
+      "optional": true
     }
   ],
   "uiRecipes": [

--- a/api/src/home/DMT/data/demoDSAlias/DMT-demo/Plugins/Form/FormExample.json
+++ b/api/src/home/DMT/data/demoDSAlias/DMT-demo/Plugins/Form/FormExample.json
@@ -1,10 +1,17 @@
 {
   "_id": "FormExample",
   "type": "/Plugins/Form/FormBlueprint",
+  "name": "FormExample",
   "aString": "a simple string",
   "aNumber": 1337,
   "listOfStrings": [
     "foo",
     "bar"
-  ]
+  ],
+  "aNestedObject" : {
+    "type": "/Plugins/Form/Nested",
+    "foo": 1337,
+    "bar": "hello",
+    "baz": "testing"
+  }
 }

--- a/api/src/home/DMT/data/demoDSAlias/DMT-demo/Plugins/Form/Nested.json
+++ b/api/src/home/DMT/data/demoDSAlias/DMT-demo/Plugins/Form/Nested.json
@@ -1,0 +1,37 @@
+{
+  "name": "Nested",
+  "type": "system/SIMOS/Blueprint",
+  "extends": [
+    "system/SIMOS/DefaultUiRecipes",
+    "system/SIMOS/NamedEntity"
+  ],
+  "attributes": [
+    {
+      "name": "foo",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "number",
+      "label":  "Foo"
+    },
+    {
+      "name": "bar",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "label":  "Bar"
+    },
+    {
+      "name": "baz",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "label":  "Baz",
+      "optional": true
+    }
+  ],
+  "uiRecipes": [
+    {
+      "name": "Form",
+      "type": "system/SIMOS/UiRecipe",
+      "plugin": "form",
+      "category": "edit"
+    }
+  ]
+}

--- a/api/src/home/DMT/data/demoDSAlias/DMT-demo/Plugins/Form/SingeField.json
+++ b/api/src/home/DMT/data/demoDSAlias/DMT-demo/Plugins/Form/SingeField.json
@@ -1,0 +1,19 @@
+{
+  "name": "SingleField",
+  "type": "system/SIMOS/Blueprint",
+  "attributes": [
+    {
+      "name": "foo",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string"
+    }
+  ],
+  "uiRecipes": [
+    {
+      "name": "Form",
+      "type": "system/SIMOS/UiRecipe",
+      "plugin": "form",
+      "category": "edit"
+    }
+  ]
+}

--- a/api/src/home/DMT/data/demoDSAlias/DMT-demo/Plugins/Form/SingleFieldExample.json
+++ b/api/src/home/DMT/data/demoDSAlias/DMT-demo/Plugins/Form/SingleFieldExample.json
@@ -1,0 +1,5 @@
+{
+  "_id": "SingleFieldExample",
+  "type": "/Plugins/Form/SingleField",
+  "name": "SingleField"
+}

--- a/api/src/home/analysis-platform/data/AnalysisPlatformDS/Blueprints/Analysis.json
+++ b/api/src/home/analysis-platform/data/AnalysisPlatformDS/Blueprints/Analysis.json
@@ -54,5 +54,13 @@
       "attributeType": "string",
       "optional": true
     }
+  ],
+  "uiRecipes": [
+    {
+      "name": "Form",
+      "type": "system/SIMOS/UiRecipe",
+      "plugin": "form",
+      "category": "edit"
+    }
   ]
 }

--- a/web/packages/plugins/ui/form/README.md
+++ b/web/packages/plugins/ui/form/README.md
@@ -27,4 +27,3 @@ The form is made up from fields and widgets:
 ![your-UML-diagram-name](docs/components.png)
 
 The attribute field selects correct fields for each attribute.
-

--- a/web/packages/plugins/ui/form/src/Form.tsx
+++ b/web/packages/plugins/ui/form/src/Form.tsx
@@ -19,7 +19,8 @@ export const Form = (props: FormProps) => {
   const namePath: string = ''
 
   const handleSubmit = methods.handleSubmit(
-    (data: UnpackNestedValue<TFieldValues>) => {
+    (data: UnpackNestedValue<TFieldValues>, errors: any) => {
+      // if (errors) console.debug(errors);
       if (onSubmit) onSubmit(data)
     }
   )
@@ -27,9 +28,7 @@ export const Form = (props: FormProps) => {
   return (
     <FormProvider {...methods}>
       <form onSubmit={handleSubmit}>
-        {type && (
-          <ObjectField namePath={namePath} formData={formData} type={type} />
-        )}
+        {type && <ObjectField namePath={namePath} type={type} />}
         <Button type="submit">Submit</Button>
       </form>
     </FormProvider>

--- a/web/packages/plugins/ui/form/src/fields/ArrayField.tsx
+++ b/web/packages/plugins/ui/form/src/fields/ArrayField.tsx
@@ -11,7 +11,7 @@ const Wrapper = styled.div`
 `
 
 export default function Fields(props: any) {
-  const { namePath, label, name, type } = props
+  const { namePath, displayLabel, type } = props
 
   const { control } = useFormContext()
 
@@ -22,16 +22,13 @@ export default function Fields(props: any) {
 
   return (
     <Wrapper>
-      <Typography>
-        {label === undefined || label === '' ? name : label}
-      </Typography>
+      <Typography>{displayLabel}</Typography>
       <div>
         {fields.map((item: any, index: number) => {
           return (
             <div key={item.id}>
               <AttributeField
                 namePath={`${namePath}.${index}`}
-                formData={item}
                 attribute={{
                   attributeType: type,
                   dimensions: '',

--- a/web/packages/plugins/ui/form/src/fields/AttributeField.tsx
+++ b/web/packages/plugins/ui/form/src/fields/AttributeField.tsx
@@ -22,18 +22,29 @@ const getFieldType = (attribute: any) => {
   }
 }
 
+const getDisplayLabel = (attribute: any): string => {
+  const { name, label, optional } = attribute
+
+  const displayLabel = label === undefined || label === '' ? name : label
+
+  return optional ? `${displayLabel} (optional)` : displayLabel
+}
+
 export const AttributeField = (props: AttributeFieldProps) => {
-  const { namePath, attribute, formData } = props
+  const { namePath, attribute } = props
 
   const fieldType = getFieldType(attribute)
+
+  const displayLabel = getDisplayLabel(attribute)
 
   switch (fieldType) {
     case 'object':
       return (
         <ObjectField
           namePath={namePath}
-          formData={formData}
+          displayLabel={displayLabel}
           type={attribute.attributeType}
+          optional={attribute.optional}
         />
       )
 
@@ -41,27 +52,24 @@ export const AttributeField = (props: AttributeFieldProps) => {
       return (
         <ArrayField
           namePath={namePath}
-          formData={formData}
-          name={attribute.name}
+          displayLabel={displayLabel}
           type={attribute.attributeType}
-          label={attribute.label}
         />
       )
     case 'string':
       return (
         <StringField
           namePath={namePath}
-          label={attribute.label}
-          name={attribute.name}
+          displayLabel={displayLabel}
           defaultValue={attribute.default}
+          optional={attribute.optional}
         />
       )
     case 'boolean':
       return (
         <BooleanField
           namePath={namePath}
-          label={attribute.label}
-          name={attribute.name}
+          displayLabel={displayLabel}
           defaultValue={attribute.default}
         />
       )
@@ -70,9 +78,9 @@ export const AttributeField = (props: AttributeFieldProps) => {
       return (
         <NumberField
           namePath={namePath}
-          label={attribute.label}
-          name={attribute.name}
+          displayLabel={displayLabel}
           defaultValue={attribute.default}
+          optional={attribute.optional}
         />
       )
     default:

--- a/web/packages/plugins/ui/form/src/fields/BooleanField.test.tsx
+++ b/web/packages/plugins/ui/form/src/fields/BooleanField.test.tsx
@@ -5,6 +5,10 @@ import { mockGetBlueprint } from '../test-utils'
 import userEvent from '@testing-library/user-event'
 
 describe('BooleanField', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   describe('TextWidget', () => {
     it('should render a single boolean field', async () => {
       mockGetBlueprint([

--- a/web/packages/plugins/ui/form/src/fields/BooleanField.tsx
+++ b/web/packages/plugins/ui/form/src/fields/BooleanField.tsx
@@ -6,7 +6,7 @@ import { BooleanFieldProps } from '../types'
 
 export const BooleanField = (props: BooleanFieldProps) => {
   const { control } = useFormContext()
-  const { namePath, label, name, defaultValue } = props
+  const { namePath, displayLabel, defaultValue } = props
 
   // We need to convert default values coming from the API since they are always strings
   const usedDefaultValue = defaultValue !== undefined && defaultValue == 'True'
@@ -17,11 +17,6 @@ export const BooleanField = (props: BooleanFieldProps) => {
     <Controller
       name={namePath}
       control={control}
-      rules={
-        {
-          // TODO: required: 'Required'
-        }
-      }
       defaultValue={usedDefaultValue}
       render={({
         // @ts-ignore
@@ -33,7 +28,7 @@ export const BooleanField = (props: BooleanFieldProps) => {
           {...props}
           id={namePath}
           value={value}
-          label={label === undefined || label === '' ? name : label}
+          label={displayLabel}
           inputRef={ref}
           helperText={error?.message}
           variant={invalid ? 'error' : 'default'}

--- a/web/packages/plugins/ui/form/src/fields/NumberField.test.tsx
+++ b/web/packages/plugins/ui/form/src/fields/NumberField.test.tsx
@@ -121,5 +121,54 @@ describe('NumberField', () => {
         }
       })
     })
+
+    it('should handle optional', async () => {
+      mockGetBlueprint([
+        {
+          name: 'SingleField',
+          type: 'system/SIMOS/Blueprint',
+          attributes: [
+            {
+              name: 'foo',
+              type: 'system/SIMOS/BlueprintAttribute',
+              attributeType: 'number',
+              optional: true,
+            },
+          ],
+        },
+      ])
+      const onSubmit = jest.fn()
+      render(<Form type="SingleField" onSubmit={onSubmit} />)
+      await waitFor(() => {
+        fireEvent.submit(screen.getByRole('button'))
+        expect(onSubmit).toHaveBeenCalled()
+        expect(onSubmit).toHaveBeenCalledWith({})
+        expect(screen.getByText('foo (optional)')).toBeDefined()
+      })
+    })
+
+    it('should not call onSubmit if non-optional field are missing value', async () => {
+      mockGetBlueprint([
+        {
+          name: 'SingleField',
+          type: 'system/SIMOS/Blueprint',
+          attributes: [
+            {
+              name: 'foo',
+              type: 'system/SIMOS/BlueprintAttribute',
+              attributeType: 'number',
+              optional: false,
+            },
+          ],
+        },
+      ])
+      const onSubmit = jest.fn()
+      render(<Form type="SingleField" onSubmit={onSubmit} />)
+      fireEvent.submit(screen.getByRole('button'))
+      await waitFor(() => {
+        expect(onSubmit).not.toHaveBeenCalled()
+        expect(onSubmit).toHaveBeenCalledTimes(0)
+      })
+    })
   })
 })

--- a/web/packages/plugins/ui/form/src/fields/NumberField.tsx
+++ b/web/packages/plugins/ui/form/src/fields/NumberField.tsx
@@ -2,6 +2,7 @@ import TextWidget from '../widgets/TextWidget'
 import React from 'react'
 // @ts-ignore
 import { Controller, useFormContext } from 'react-hook-form'
+import { NumberFieldProps } from '../types'
 
 // Taken from: https://github.com/rjsf-team/react-jsonschema-form/blob/cff979dae5348e9b100447641bcb53374168367f/packages/core/src/utils.js#L436
 export const asNumber = (value: string): number | string => {
@@ -30,9 +31,9 @@ export const asNumber = (value: string): number | string => {
   return valid ? n : value
 }
 
-export const NumberField = (props: any) => {
+export const NumberField = (props: NumberFieldProps) => {
   const { control } = useFormContext()
-  const { namePath, label, name, defaultValue } = props
+  const { namePath, displayLabel, defaultValue, optional } = props
 
   // TODO: const Widget = getWidget(schema, widget, widgets);
 
@@ -41,14 +42,10 @@ export const NumberField = (props: any) => {
       name={namePath}
       control={control}
       rules={{
-        // TODO: required: 'Required',
+        required: !optional,
         pattern: { value: /^[0-9]+$/g, message: 'Only digits allowed' },
       }}
-      defaultValue={defaultValue || ''}
-      // @ts-ignore
-      onChange={(value: any) => {
-        return console.log(value)
-      }}
+      defaultValue={defaultValue || undefined}
       render={({
         // @ts-ignore
         field: { ref, onChange, ...props },
@@ -65,7 +62,7 @@ export const NumberField = (props: any) => {
             onChange={handleChange}
             type="number"
             id={namePath}
-            label={label === undefined || label === '' ? name : label}
+            label={displayLabel}
             inputRef={ref}
             helperText={error?.message}
             variant={invalid ? 'error' : 'default'}

--- a/web/packages/plugins/ui/form/src/fields/ObjectField.test.tsx
+++ b/web/packages/plugins/ui/form/src/fields/ObjectField.test.tsx
@@ -98,6 +98,46 @@ describe('ObjectField', () => {
     })
   })
 
+  it('should handle optional', async () => {
+    mockGetBlueprint([
+      {
+        type: 'system/SIMOS/Blueprint',
+        name: 'Parent',
+        attributes: [
+          {
+            name: 'nested',
+            type: 'system/SIMOS/BlueprintAttribute',
+            attributeType: 'Nested',
+            optional: true,
+          },
+        ],
+      },
+      {
+        type: 'system/SIMOS/Blueprint',
+        name: 'Nested',
+        attributes: [
+          {
+            name: 'foo',
+            type: 'system/SIMOS/BlueprintAttribute',
+            attributeType: 'string',
+          },
+        ],
+      },
+    ])
+    const onSubmit = jest.fn()
+    render(<Form type="Parent" onSubmit={onSubmit} />)
+    await waitFor(() => {
+      // It's ok to submit
+      fireEvent.submit(screen.getByText('Submit'))
+      expect(onSubmit).toHaveBeenCalled()
+      expect(onSubmit).toHaveBeenCalledWith({})
+      // Show optional in label
+      expect(screen.getByText('nested (optional)')).toBeDefined()
+      // Add button
+      expect(screen.getByTestId('add-nested')).toBeDefined()
+    })
+  })
+
   describe.skip('fields ordering', () => {})
 
   describe.skip('Title', () => {})

--- a/web/packages/plugins/ui/form/src/fields/ObjectField.tsx
+++ b/web/packages/plugins/ui/form/src/fields/ObjectField.tsx
@@ -1,9 +1,10 @@
 import { useBlueprint } from '@dmt/common'
-import React from 'react'
+import React, { useState } from 'react'
 import { AttributeField } from './AttributeField'
-import { Typography } from '@equinor/eds-core-react'
+import { Button, Typography } from '@equinor/eds-core-react'
 import styled from 'styled-components'
 import { ObjectFieldProps } from '../types'
+import { useFormContext } from 'react-hook-form'
 
 const Wrapper = styled.div`
   margin-top: 20px;
@@ -13,36 +14,83 @@ const AttributeListWrapper = styled.div`
   margin-top: 30px;
 `
 
-export const ObjectField = (props: ObjectFieldProps) => {
-  const { namePath, type, formData } = props
+const AddObject = (props: any) => {
+  const { type, namePath, onAdd } = props
+  const { setValue } = useFormContext()
 
-  // TODO: How to handle object type?
-  if (type === 'object') return <></>
+  const handleAdd = () => {
+    // TODO: Fill with default values using createEntity?
+    const values = {
+      type: type,
+    }
+    const options = {
+      shouldValidate: true,
+      shouldDirty: true,
+      shouldTouch: true,
+    }
+    setValue(namePath, values, options)
+    onAdd()
+  }
+  return (
+    <Button data-testid={`add-${namePath}`} onClick={handleAdd}>
+      Add
+    </Button>
+  )
+}
 
-  const [blueprint, isLoadingBlueprint, error] = useBlueprint(type)
+const withOptional = (WrappedComponent: any) => (props: any) => {
+  const { type, namePath } = props
 
-  if (isLoadingBlueprint) return <div>Loading...</div>
+  const { getValues } = useFormContext()
+  const initialValue = getValues(namePath) !== undefined
+  const [isDefined, setIsDefined] = useState(initialValue)
+
+  if (!isDefined) {
+    return (
+      <AddObject
+        namePath={namePath}
+        type={type}
+        onAdd={() => setIsDefined(true)}
+      />
+    )
+  } else {
+    return <WrappedComponent {...props} />
+  }
+}
+
+const AttributeList = (props: any) => {
+  const { type, namePath } = props
+
+  const [blueprint, isLoading, error] = useBlueprint(type)
+  if (isLoading) return <div>Loading...</div>
   if (blueprint === undefined) return <div>Could not find blueprint</div>
 
   const prefix = namePath === '' ? `` : `${namePath}.`
-
   const attributeFields = blueprint.attributes.map((attribute: any) => {
-    const data =
-      formData && attribute.name in formData ? formData[attribute.name] : ''
     return (
       <AttributeField
         key={`${prefix}${attribute.name}`}
         namePath={`${prefix}${attribute.name}`}
         attribute={attribute}
-        formData={data}
       />
     )
   })
 
+  return <AttributeListWrapper>{attributeFields}</AttributeListWrapper>
+}
+
+export const ObjectField = (props: ObjectFieldProps) => {
+  const { type, namePath, displayLabel = '', optional = false } = props
+
+  // TODO: How to handle object type?
+  if (type === 'object') return <></>
+
+  const Content = optional ? withOptional(AttributeList) : AttributeList
+
   return (
     <Wrapper>
-      <Typography>{blueprint.name}</Typography>
-      <AttributeListWrapper>{attributeFields}</AttributeListWrapper>
+      <Typography>{displayLabel}</Typography>
+      <Content type={type} namePath={namePath} />
     </Wrapper>
   )
 }

--- a/web/packages/plugins/ui/form/src/fields/StringField.test.tsx
+++ b/web/packages/plugins/ui/form/src/fields/StringField.test.tsx
@@ -5,6 +5,10 @@ import { mockGetBlueprint } from '../test-utils'
 import userEvent from '@testing-library/user-event'
 
 describe('StringField', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   describe('TextWidget', () => {
     it('should render a single string field', async () => {
       mockGetBlueprint([
@@ -218,7 +222,7 @@ describe('StringField', () => {
       })
     })
 
-    it('should default submit value to empty string', async () => {
+    it('should default submit value to empty object', async () => {
       mockGetBlueprint([
         {
           name: 'SingleField',
@@ -240,9 +244,59 @@ describe('StringField', () => {
       await waitFor(() => {
         fireEvent.submit(screen.getByRole('button'))
         expect(onSubmit).toHaveBeenCalled()
-        expect(onSubmit).toHaveBeenCalledWith({
-          foo: '',
-        })
+        expect(onSubmit).toHaveBeenCalledWith({})
+      })
+    })
+
+    it('should handle optional', async () => {
+      mockGetBlueprint([
+        {
+          name: 'SingleField',
+          type: 'system/SIMOS/Blueprint',
+          attributes: [
+            {
+              name: 'foo',
+              type: 'system/SIMOS/BlueprintAttribute',
+              attributeType: 'string',
+              optional: true,
+            },
+          ],
+        },
+      ])
+      const onSubmit = jest.fn()
+      const formData = {}
+      const { container } = render(
+        <Form type="SingleField" formData={formData} onSubmit={onSubmit} />
+      )
+      await waitFor(() => {
+        fireEvent.submit(screen.getByRole('button'))
+        expect(onSubmit).toHaveBeenCalled()
+        expect(onSubmit).toHaveBeenCalledWith({})
+        expect(screen.getByText('foo (optional)')).toBeDefined()
+      })
+    })
+
+    it('should not call onSubmit if non-optional field are missing value', async () => {
+      mockGetBlueprint([
+        {
+          name: 'SingleField',
+          type: 'system/SIMOS/Blueprint',
+          attributes: [
+            {
+              name: 'foo',
+              type: 'system/SIMOS/BlueprintAttribute',
+              attributeType: 'string',
+              optional: false,
+            },
+          ],
+        },
+      ])
+      const onSubmit = jest.fn()
+      render(<Form type="SingleField" onSubmit={onSubmit} />)
+      fireEvent.submit(screen.getByRole('button'))
+      await waitFor(() => {
+        expect(onSubmit).not.toHaveBeenCalled()
+        expect(onSubmit).toHaveBeenCalledTimes(0)
       })
     })
 

--- a/web/packages/plugins/ui/form/src/fields/StringField.tsx
+++ b/web/packages/plugins/ui/form/src/fields/StringField.tsx
@@ -2,10 +2,11 @@ import TextWidget from '../widgets/TextWidget'
 import React from 'react'
 // @ts-ignore
 import { Controller, useFormContext } from 'react-hook-form'
+import { StringFieldProps } from '../types'
 
-export const StringField = (props: any) => {
+export const StringField = (props: StringFieldProps) => {
   const { control } = useFormContext()
-  const { namePath, label, name, defaultValue } = props
+  const { namePath, displayLabel, defaultValue, optional } = props
 
   // TODO: const Widget = getWidget(schema, widget, widgets);
 
@@ -13,11 +14,9 @@ export const StringField = (props: any) => {
     <Controller
       name={namePath}
       control={control}
-      rules={
-        {
-          // TODO: required: 'Required',
-        }
-      }
+      rules={{
+        required: !optional,
+      }}
       defaultValue={defaultValue || ''}
       render={({
         // @ts-ignore
@@ -28,7 +27,7 @@ export const StringField = (props: any) => {
         <TextWidget
           {...props}
           id={namePath}
-          label={label === undefined || label === '' ? name : label}
+          label={displayLabel}
           inputRef={ref}
           helperText={error?.message}
           variant={invalid ? 'error' : 'default'}

--- a/web/packages/plugins/ui/form/src/index.tsx
+++ b/web/packages/plugins/ui/form/src/index.tsx
@@ -4,9 +4,10 @@ import { DmtPluginType, DmtUIPlugin } from '@dmt/common'
 import { Form } from './Form'
 
 const PluginComponent = (props: DmtUIPlugin) => {
-  const { document, uiRecipeName, onSubmit } = props
+  const { document, config, onSubmit } = props
 
-  // TODO: Use uiRecipeName to customize the form
+  // TODO: Use config to customize the form
+  // @ts-ignore
   return <Form type={document.type} formData={document} onSubmit={onSubmit} />
 }
 

--- a/web/packages/plugins/ui/form/src/types.tsx
+++ b/web/packages/plugins/ui/form/src/types.tsx
@@ -7,25 +7,31 @@ export type FormProps = {
 export type ObjectFieldProps = {
   namePath: string
   type: string
-  formData?: any
+  displayLabel?: string
+  optional?: boolean
 }
 
 export type AttributeFieldProps = {
   namePath: string
   attribute: any
-  formData?: any
 }
 
 export type StringFieldProps = {
   namePath: string
-  label: string
-  name: string
+  displayLabel: string
   defaultValue: string
+  optional: boolean
+}
+
+export type NumberFieldProps = {
+  namePath: string
+  displayLabel: string
+  defaultValue: string
+  optional: boolean
 }
 
 export type BooleanFieldProps = {
   namePath: string
-  label: string
-  name: string
+  displayLabel: string
   defaultValue: string
 }

--- a/web/packages/plugins/ui/form/src/widgets/TextWidget/TextWidget.tsx
+++ b/web/packages/plugins/ui/form/src/widgets/TextWidget/TextWidget.tsx
@@ -12,7 +12,6 @@ const TextWidget = (props: any) => {
   const _onChange = ({
     target: { value },
   }: React.ChangeEvent<HTMLInputElement>) => onChange(value === '' ? '' : value)
-
   return <TextField {...props} onChange={_onChange} label={label} />
 }
 


### PR DESCRIPTION
## What does this pull request change?

- [x] Add (optional) to labels for primitives, nested objects
- [x] Shows "Add" button nested blueprint attributes that are optional and does not have any values defined
- [x] Form will not submit before all non-optional values have values (are not undefined)

## Why is this pull request needed?

* It should be visible to the users what attributes are optional or not
 
<img width="935" alt="image" src="https://user-images.githubusercontent.com/1190419/158783213-60bc18b2-c304-45f0-a800-662dde05e3f8.png">

* It should not be possible to submit form before all non-optional attributes have values

<img width="1122" alt="image" src="https://user-images.githubusercontent.com/1190419/158783265-4bd0ea1f-91b9-41ea-ae22-4909df330884.png">

## Issues related to this change:

Part of #1072 
