### PR TITLE
update date stored in job handler

### DIFF
--- a/api/src/services/job_handler_interface.py
+++ b/api/src/services/job_handler_interface.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from enum import Enum
 from typing import Tuple
+from dateutil import parser
 
 
 class JobStatus(Enum):
@@ -57,10 +58,10 @@ class Job:
     def from_dict(cls, a_dict: dict):
         return Job(
             job_id=a_dict["job_id"],
-            started=datetime.fromisoformat(a_dict["started"]),
+            started=parser.parse(a_dict["started"]).utcnow().isoformat() + "Z",
             status=JobStatus(a_dict["status"]),
             entity=a_dict["entity"],
-            stopped=datetime.fromisoformat(a_dict["stopped"]),
+            stopped=parser.parse(a_dict["stopped"]).utcnow().isoformat() + "Z",
             log=a_dict.get("log"),
             cron_job=a_dict.get("cron_job"),
             token=a_dict.get("token"),

--- a/web/packages/plugins/ui/job/src/Job.tsx
+++ b/web/packages/plugins/ui/job/src/Job.tsx
@@ -131,7 +131,7 @@ export const JobLog = (props: { document: any; jobId: string }) => {
           <Label label="Started:" />
           <label>
             {new Date(document.started).toLocaleString(navigator.language)}
-            (local)
+            {' (local)'}
           </label>
         </RowGroup>
         <RowGroup>


### PR DESCRIPTION
## What does this pull request change?
bugfix: the python conversion to isoformat was not as expected.
This caused the job entity in the mongodb to have wrong dateformat for "started"
![image](https://user-images.githubusercontent.com/69512295/162431610-4af1f13d-da54-4c46-b415-76f3c9c39513.png)


instead of having the ISO format "2022-04-08T11:23:18.686Z",
the string was stored in local time without the Z: "2022-04-08T13:23:18.686"

## Why is this pull request needed?
the start time in the job runs table was wrong
![image](https://user-images.githubusercontent.com/69512295/162431316-3c67101b-ef1b-40a9-8076-a5f0e0e4000a.png)
 
## Issues related to this change:

closes #1083