### PR TITLE
Run apt upgrades on sre-wrapper image

### DIFF
--- a/sre-wrapper/Dockerfile
+++ b/sre-wrapper/Dockerfile
@@ -1,6 +1,9 @@
 FROM dmtregistry.azurecr.io/sima-runtime:latest
 LABEL Description="Docker image for Data Modelling Tool SIMA Headless Job Wrapper"
 
+RUN apt-get update && \
+    apt-get -y upgrade
+
 RUN pip install --upgrade pip && \
     pip install poetry && \
     poetry config virtualenvs.create false


### PR DESCRIPTION
## What does this pull request change?
- Ensures apt packages are up to date in the container image as we're relying on a third-party (SINTEF-managed) container image (`dmtregistry.azurecr.io/sima-runtime`)

## Why is this pull request needed?
- To ensure packages are up to date;
- To minimize the exposure to vulnerabilities in outdated/old packages

## Issues related to this change:

## Checklist

- [ ] Your code builds clean without any errors or warnings
- [ ] You are using approved terminology
- [ ] You have added types and interfaces where possible
- [ ] You have added tests
- [ ] You have updated documentation
- [ ] You use defined architecture principles and project structures
- [ ] You are happy with the code quality
