### PR TITLE
Bugfix: the edit plugin crashed for new analysis

### DIFF
--- a/web/packages/plugins/ui/task/src/EditTask.tsx
+++ b/web/packages/plugins/ui/task/src/EditTask.tsx
@@ -71,7 +71,7 @@ export const EditTask = (props: DmtUIPlugin) => {
                 onChange={(selectedBlueprint: string) =>
                   setFormData({ ...formData, inputType: selectedBlueprint })
                 }
-                formData={formData.inputType}
+                formData={formData?.inputType || ''}
               />
             </Column>
             <div
@@ -141,7 +141,7 @@ export const EditTask = (props: DmtUIPlugin) => {
                 onChange={(selectedBlueprint: string) =>
                   setFormData({ ...formData, outputType: selectedBlueprint })
                 }
-                formData={formData.outputType}
+                formData={formData?.outputType || ''}
               />
             </Column>
           </GroupWrapper>


### PR DESCRIPTION
## What does this pull request change?
Added or-argument as input for formData, so truncatepathstring works.

## Why is this pull request needed?
To be able to get the edit plugin for analysis with no data. 

## Issues related to this change

