### PR TITLE
result in jobTable now points to the result

### DIFF
--- a/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/components/AnalysisJobTable.tsx
+++ b/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/components/AnalysisJobTable.tsx
@@ -56,17 +56,20 @@ const JobRow = (props: { job: TJob; index: number; analysisId: string }) => {
       <Table.Cell>{}</Table.Cell>
       <Table.Cell>{jobStatus}</Table.Cell>
       <Table.Cell>
-        <ClickableLabel
-          onClick={(e) => {
-            window.open(
-              `/ap/view/${DEFAULT_DATASOURCE_ID}/${analysisId}.jobs.${index}`,
-              '_blank'
-            )
-            e.stopPropagation()
-          }}
-        >
-          Open
-        </ClickableLabel>
+        {Object.keys(job?.result || {}).length ? (
+          <ClickableLabel
+            onClick={() => {
+              window.open(
+                `/ap/view/${DEFAULT_DATASOURCE_ID}/${job.result?._id}`,
+                '_blank'
+              )
+            }}
+          >
+            Open
+          </ClickableLabel>
+        ) : (
+          <>None</>
+        )}
       </Table.Cell>
     </Table.Row>
   )


### PR DESCRIPTION
## What does this pull request change?
Changed the url-path for the result in the jobTable to show the result. 
If the result don't exist it will show "None"

## Why is this pull request needed?

## Issues related to this change

