### PR TITLE
expert operator task view plugin. Impersonate feature

### DIFF
--- a/api/src/home/analysis-platform/data/WorkflowDS/Blueprints/Task.json
+++ b/api/src/home/analysis-platform/data/WorkflowDS/Blueprints/Task.json
@@ -3,6 +3,7 @@
   "abstract": true,
   "type": "system/SIMOS/Blueprint",
   "description": "Task holds parameters that is used to create different job instances",
+  "extends": ["system/SIMOS/DefaultUiRecipes"],
   "attributes": [
     {
       "name": "outputTarget",
@@ -10,16 +11,14 @@
       "attributeType": "string",
       "description": "Reference to a location where the result should be stored (path format)",
       "optional": true
-    },
-    {
+    }, {
       "attributeType": "string",
       "type": "system/SIMOS/BlueprintAttribute",
       "name": "inputType",
       "label": "Input type",
       "description": "Reference to a Blueprint",
       "optional": true
-    },
-    {
+    }, {
       "attributeType": "object",
       "type": "system/SIMOS/BlueprintAttribute",
       "name": "applicationInput",
@@ -27,16 +26,14 @@
       "description": "Input entity for container",
       "contained": false,
       "optional": true
-    },
-    {
+    }, {
       "attributeType": "string",
       "type": "system/SIMOS/BlueprintAttribute",
       "name": "outputType",
       "label": "Output type",
       "description": "Reference to a Blueprint",
       "optional": true
-    },
-    {
+    }, {
       "attributeType": "/jobHandlers/JobHandler",
       "type": "system/SIMOS/BlueprintAttribute",
       "name": "runner",
@@ -45,32 +42,19 @@
       "optional": true
     }
   ],
-    "uiRecipes": [
+  "uiRecipes": [
     {
-      "name": "Tabs",
-      "label": "Tabs",
-      "type": "system/SIMOS/UiRecipe",
-      "plugin": "tabs",
-      "category": "container",
-      "config": {
-        "type": "system/SIMOS/UiPluginSelectorProps",
-        "subCategories": ["edit", "container"]
-      }
-    },
-      {
-      "name": "Yaml",
-      "label": "View",
-      "type": "system/SIMOS/UiRecipe",
-      "plugin": "yaml-view",
-      "category": "view",
-      "roles": ["operator"]
-    },
-      {
       "name": "Edit",
       "type": "system/SIMOS/UiRecipe",
       "plugin": "edit-task",
       "category": "edit",
-      "roles": ["expert"]
+      "roles": ["dmss-admin", "domain-expert", "domain-developer"]
+    }, {
+      "name": "Edit Input",
+      "type": "system/SIMOS/UiRecipe",
+      "plugin": "edit-task-expert-operator",
+      "category": "edit",
+      "roles": ["expert-operator"]
     }
   ]
 }

--- a/api/src/home/appMooring/data/app_mooring_db/simpos/mooringSRS/MooringSRS.json
+++ b/api/src/home/appMooring/data/app_mooring_db/simpos/mooringSRS/MooringSRS.json
@@ -55,28 +55,26 @@
       "name": "SRS Sce Form",
       "description": "Some external plugin",
       "plugin": "simpos-srs-sce-form",
-      "attributes": []
+      "category": "edit"
     },
     {
       "type": "system/SIMOS/UiRecipe",
       "name": "SRS Simulation",
       "description": "Some external plugin",
-      "plugin": "simpos-srs-sce-simulation-form",
-      "attributes": []
+      "plugin": "simpos-srs-sce-simulation-form"
     },
     {
       "type": "system/SIMOS/UiRecipe",
       "name": "SIMOS Raw View",
       "description": "Some external plugin",
       "plugin": "simos-raw-view",
-      "attributes": []
+      "category": "view"
     },
     {
       "type": "system/SIMOS/UiRecipe",
       "name": "Blueprint",
       "description": "Viewing the entities Blueprint.",
-      "plugin": "dmt-blueprint-table-view",
-      "attributes": []
+      "plugin": "dmt-blueprint-table-view"
     }
   ]
 }

--- a/web/packages/plugins/apps/analysis-platform/src/App.tsx
+++ b/web/packages/plugins/apps/analysis-platform/src/App.tsx
@@ -13,7 +13,7 @@ const MainLayout = (props: TLayout) => {
   const { heading, content, settings } = props
   return (
     <>
-      <Header appName={settings.label} homeUrl={settings.name} />
+      <Header appName={settings.label} />
       <Layout style={{ background: backgroundColorDefault }}>
         <Menu appRootPath={settings.urlPath} />
         <Content settings={settings} heading={heading} content={content} />

--- a/web/packages/plugins/apps/analysis-platform/src/components/Layout/Header.tsx
+++ b/web/packages/plugins/apps/analysis-platform/src/components/Layout/Header.tsx
@@ -1,9 +1,9 @@
 import React, { useContext, useState } from 'react'
-import { TopBar } from '@equinor/eds-core-react'
+import { Radio, TopBar } from '@equinor/eds-core-react'
 import styled from 'styled-components'
 import Icon from '../Design/Icons'
 import { Link } from 'react-router-dom'
-import { AuthContext, Dialog } from '@dmt/common'
+import { AuthContext, Dialog, useLocalStorage } from '@dmt/common'
 
 const Icons = styled.div`
   display: flex;
@@ -19,6 +19,12 @@ export const ClickableIcon = styled.div`
     color: gray;
     cursor: pointer;
   }
+`
+const UnstyledList = styled.ul`
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+  display: inline-flex;
 `
 
 const StyledLink = styled(Link)`
@@ -36,10 +42,15 @@ const StyledLink = styled(Link)`
   }
 `
 
-export default (props: { appName: string; homeUrl: string }): JSX.Element => {
-  const { appName, homeUrl } = props
+export default (props: { appName: string }): JSX.Element => {
+  const { appName } = props
   const [visibleUserInfo, setVisibleUserInfo] = useState<boolean>(false)
   const { tokenData } = useContext(AuthContext)
+  const [checked, updateChecked] = useLocalStorage<string | null>(
+    'impersonateRoles',
+    null
+  )
+
   return (
     <TopBar>
       <TopBar.Header>
@@ -78,6 +89,32 @@ export default (props: { appName: string; homeUrl: string }): JSX.Element => {
             2
           )}
         </pre>
+        {tokenData?.roles.includes('dmss-admin') && (
+          <>
+            <p>Impersonate a role (UI only)</p>
+            <UnstyledList>
+              {[
+                'dmss-admin',
+                'operator',
+                'expert-operator',
+                'domain-expert',
+                'domain-developer',
+              ].map((role: string) => (
+                <li>
+                  <Radio
+                    key={role}
+                    label={role}
+                    name="impersonate-role"
+                    value={role}
+                    checked={checked === role}
+                    //@ts-ignore
+                    onChange={(e: any) => updateChecked(e.target.value)}
+                  />
+                </li>
+              ))}
+            </UnstyledList>
+          </>
+        )}
       </Dialog>
     </TopBar>
   )

--- a/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/AnalysisView.tsx
+++ b/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/AnalysisView.tsx
@@ -1,6 +1,6 @@
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { AuthContext, UIPluginSelector, useDocument } from '@dmt/common'
+import { UIPluginSelector, useDocument } from '@dmt/common'
 import { Progress } from '@equinor/eds-core-react'
 import AnalysisInfoCard from './components/AnalysisInfo'
 import AnalysisJobTable from './components/AnalysisJobTable'
@@ -36,7 +36,7 @@ export default (): JSX.Element => {
         <UIPluginSelector
           entity={analysis.task}
           absoluteDottedId={`${data_source}/${analysis._id}.task`}
-          categories={['container', 'view']}
+          categories={['container', 'view', 'edit']}
         />
         <AnalysisJobTable jobs={jobs} analysisId={analysis._id} />
       </>

--- a/web/packages/plugins/apps/analysis-platform/src/utils/auth.tsx
+++ b/web/packages/plugins/apps/analysis-platform/src/utils/auth.tsx
@@ -1,4 +1,9 @@
-const EXPERT_ROLES = ['EXPERT', 'dmss-admin']
+const EXPERT_ROLES = [
+  'expert-operator',
+  'domain-developer',
+  'domain-expert',
+  'dmss-admin',
+]
 
 export function hasExpertRole(userData: any): boolean {
   // Always return true if auth is not enabled

--- a/web/packages/plugins/shared/common/src/components/UiPluginSelector.tsx
+++ b/web/packages/plugins/shared/common/src/components/UiPluginSelector.tsx
@@ -108,7 +108,6 @@ function filterPlugins(
     }
     return true
   })
-
   // If there are no recipes with the correct filter, show fallback
   if (!uiRecipes.length) {
     return fallbackPlugin
@@ -153,6 +152,9 @@ export function UIPluginSelector(props: {
   // @ts-ignore
   const { loading, getUiPlugin } = useContext(UiPluginContext)
   const { tokenData } = useContext(AuthContext)
+  const roles =
+    [JSON.parse(localStorage.getItem('impersonateRoles') || 'null')] ||
+    tokenData?.roles
   const [selectedPlugin, setSelectedPlugin] = useState<number>(0)
   const [selectablePlugins, setSelectablePlugins] = useState<
     TSelectablePlugins[]
@@ -161,7 +163,7 @@ export function UIPluginSelector(props: {
   useEffect(() => {
     if (!blueprint) return
     setSelectablePlugins(
-      filterPlugins(blueprint, categories || [], tokenData?.roles, getUiPlugin)
+      filterPlugins(blueprint, categories || [], roles, getUiPlugin)
     )
   }, [blueprint])
 

--- a/web/packages/plugins/ui/task/src/SIMAInputOnly.tsx
+++ b/web/packages/plugins/ui/task/src/SIMAInputOnly.tsx
@@ -1,0 +1,18 @@
+import { DmtUIPlugin, UIPluginSelector } from '@dmt/common'
+import * as React from 'react'
+
+export const EditSIMAInput = (props: DmtUIPlugin) => {
+  const { document, documentId, dataSourceId } = props
+  if (!document?.applicationInput?.input) {
+    return <pre style={{ color: 'red' }}>No input exists for the analysis</pre>
+  }
+  return (
+    <div>
+      <UIPluginSelector
+        absoluteDottedId={`${dataSourceId}/${documentId}.applicationInput.input`}
+        entity={document?.applicationInput?.input}
+        categories={['edit']}
+      />
+    </div>
+  )
+}

--- a/web/packages/plugins/ui/task/src/index.tsx
+++ b/web/packages/plugins/ui/task/src/index.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react'
 
-import { DmtPluginType } from '@dmt/common'
+import { DmtPlugin, DmtPluginType } from '@dmt/common'
 import { EditTask } from './EditTask'
 import { ViewTask } from './ViewTask'
+import { EditSIMAInput } from './SIMAInputOnly'
 
-export const plugins: any = [
+export const plugins: DmtPlugin[] = [
   {
     pluginName: 'edit-task',
     pluginType: DmtPluginType.UI,
@@ -14,5 +15,10 @@ export const plugins: any = [
     pluginName: 'view-task',
     pluginType: DmtPluginType.UI,
     component: ViewTask,
+  },
+  {
+    pluginName: 'edit-task-expert-operator',
+    pluginType: DmtPluginType.UI,
+    component: EditSIMAInput,
   },
 ]


### PR DESCRIPTION
## What does this pull request change?
- Adds a Task plugin for operator-experts that only displays the SRSConfig
- New feature: Impersonate. dmss-admin gets the option to impersonate an other role


## Issues related to this change
closes #1194 

