### PR TITLE
upate logic for dropdown selectors

### DIFF
--- a/api/src/home/analysis-platform/data/WorkflowDS/Blueprints/jobHandlers/JobHandler.json
+++ b/api/src/home/analysis-platform/data/WorkflowDS/Blueprints/jobHandlers/JobHandler.json
@@ -10,6 +10,12 @@
       "dimensions": "*",
       "optional": true,
       "description": "a list of strings on format 'myVar=myValue'"
+    },
+    {
+      "name": "type",
+      "attributeType": "string",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "optional": false
     }
   ]
 }

--- a/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/components/AnalysisCard.tsx
+++ b/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/components/AnalysisCard.tsx
@@ -58,6 +58,15 @@ const RunAnalysisButton = (props: any) => {
   const saveAndStartJob = (task: TTask) => {
     setLoading(true)
     const runsSoFar = jobs.length
+
+    if (!task.runner || Object.keys(task.runner).length === 0) {
+      NotificationManager.error(
+        'You must save the job runner before starting the job!'
+      )
+      setLoading(false)
+      return
+    }
+
     const job: TJob = {
       label: 'Example local container job',
       name: `${analysis._id}.jobs.${runsSoFar}-${poorMansUUID(1)}`,

--- a/web/packages/plugins/shared/common/src/components/Pickers/JobHandlerPicker.tsx
+++ b/web/packages/plugins/shared/common/src/components/Pickers/JobHandlerPicker.tsx
@@ -33,13 +33,16 @@ export const JobHandlerPicker = (props: {
   return (
     <div style={{ display: 'flex', flexDirection: 'row' }}>
       <Select
-        onChange={(e: ChangeEvent<HTMLSelectElement>) =>
-          handleChange(searchResult[parseInt(e.target.value)]._id)
-        }
+        onChange={(e: ChangeEvent<HTMLSelectElement>) => {
+          return handleChange(searchResult[parseInt(e.target.value)]._id)
+        }}
         value={searchResult.findIndex(
           (resultEntry: any) => resultEntry.name === blueprintName
         )}
       >
+        <option value={-1} selected disabled hidden>
+          Choose runner...
+        </option>
         {searchResult.map((resultEntry: any, index: number) => (
           <option key={index} value={index}>
             {resultEntry.name}

--- a/web/packages/plugins/ui/job-handlers/src/EditContainer.tsx
+++ b/web/packages/plugins/ui/job-handlers/src/EditContainer.tsx
@@ -53,8 +53,13 @@ export const EditContainer = (props: DmtUIPlugin) => {
               onChange={(e: ChangeEvent<HTMLSelectElement>) =>
                 setFormData({ ...formData, image: e.target.value })
               }
-              value={formData?.image || ''}
+              value={imageOptions.find(
+                (image: string) => image === formData?.image
+              )}
             >
+              <option value={''} selected disabled hidden>
+                Choose image...
+              </option>
               {imageOptions.map((image: string, index: number) => (
                 <option key={index} value={image}>
                   {image}

--- a/web/packages/plugins/ui/task/src/EditTask.tsx
+++ b/web/packages/plugins/ui/task/src/EditTask.tsx
@@ -35,7 +35,6 @@ export const EditTask = (props: DmtUIPlugin) => {
     false
   )
   const [formData, setFormData] = useState<any>({ ...document })
-  const defaultRunnerType = 'WorkflowDS/Blueprints/jobHandlers/AzureContainer'
 
   useEffect(() => {
     if (!_document) return
@@ -147,7 +146,7 @@ export const EditTask = (props: DmtUIPlugin) => {
                     runner: { ...formData?.runner, type: selectedBlueprint },
                   })
                 }
-                formData={formData?.runner?.type || defaultRunnerType}
+                formData={formData?.runner?.type || ''}
               />
               <div
                 style={{
@@ -162,7 +161,7 @@ export const EditTask = (props: DmtUIPlugin) => {
                       onOpen({
                         attribute: 'runner',
                         entity: formData?.runner || {
-                          type: defaultRunnerType,
+                          type: '',
                         },
                         absoluteDottedId: `${dataSourceId}/${documentId}.runner`,
                         onSubmit: (data: any) =>
@@ -179,7 +178,7 @@ export const EditTask = (props: DmtUIPlugin) => {
                     absoluteDottedId={`${dataSourceId}/${documentId}.runner`}
                     entity={
                       (Object.keys(formData?.runner).length &&
-                        formData.runner) || { type: defaultRunnerType }
+                        formData.runner) || { type: '' }
                     }
                     breadcrumb={false}
                     categories={['edit']}


### PR DESCRIPTION
## What does this pull request change?
* do not use default values for dropdown selector. Force user to select a value. 
* If a value is stored on the task entity, this will be set to the value in the dropdown selector. 
* 

## Why is this pull request needed?
Values in dropdown selectors for "job runner" and "container image" displays a value, but the internal state is empty. This resulted in no values being updated in the entity when pressing save. 

no value selected (no runner stored in the task entity)
![image](https://user-images.githubusercontent.com/69512295/170205501-edb036b3-ef72-4648-8619-e20c08322782.png)


after selecting "container" as runner, press save, and reload page: value is automatically selected in the dropdown menu
![image](https://user-images.githubusercontent.com/69512295/170205655-4adb5889-aa60-4577-99ae-6de767e3c9cb.png)

##  Issues related to this change
#1208 

