### PR TITLE
Start and edit jobs refactor

### DIFF
--- a/api/src/home/analysis-platform/data/WorkflowDS/Blueprints/Job.json
+++ b/api/src/home/analysis-platform/data/WorkflowDS/Blueprints/Job.json
@@ -2,7 +2,7 @@
   "name": "Job",
   "abstract": true,
   "type": "system/SIMOS/Blueprint",
-  "extends": ["system/SIMOS/NamedEntity"],
+  "extends": ["system/SIMOS/NamedEntity", "system/SIMOS/DefaultUiRecipes"],
   "attributes": [
     {
       "name": "label",
@@ -58,7 +58,7 @@
       "optional": true
     },
     {
-      "attributeType": "string",
+      "attributeType": "/jobHandlers/JobHandler",
       "type": "system/SIMOS/BlueprintAttribute",
       "name": "runner",
       "label": "Runner",
@@ -76,15 +76,16 @@
   ],
   "uiRecipes": [
     {
-      "name": "Job",
+      "name": "Edit",
       "type": "system/SIMOS/UiRecipe",
-      "plugin": "job",
-      "category": "view"
+      "plugin": "jobEdit",
+      "category": "edit",
+      "roles": ["dmss-admin", "domain-expert", "domain-developer"]
     },
     {
-      "name": "Yaml",
+      "name": "Control pane",
       "type": "system/SIMOS/UiRecipe",
-      "plugin": "yaml-view",
+      "plugin": "jobControl",
       "category": "view"
     }
   ]

--- a/web/packages/plugins/apps/analysis-platform/src/Types.ts
+++ b/web/packages/plugins/apps/analysis-platform/src/Types.ts
@@ -43,10 +43,20 @@ export type TLayout = {
   settings: DmtSettings
 }
 
+export enum JobStatus {
+  CREATED = 'created',
+  STARTING = 'starting',
+  RUNNING = 'running',
+  FAILED = 'failed',
+  COMPLETED = 'completed',
+  UNKNOWN = 'unknown',
+}
+
 export type TJob = {
   label: string
   name: string
   type: string
+  status: JobStatus
   triggeredBy: string
   applicationInput: TReference
   runner?: TJobHandler | TContainerJobHandler

--- a/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/components/AnalysisJobTable.tsx
+++ b/web/packages/plugins/apps/analysis-platform/src/modules/Analysis/components/AnalysisJobTable.tsx
@@ -1,21 +1,13 @@
-import { Table, Typography } from '@equinor/eds-core-react'
+import { Button, Icon, Table, Typography } from '@equinor/eds-core-react'
 import React, { useContext, useEffect, useState } from 'react'
 import { AuthContext, JobApi } from '@dmt/common'
 import { DEFAULT_DATASOURCE_ID } from '../../../const'
 import styled from 'styled-components'
-import { TJob } from '../../../Types'
+import { JobStatus, TJob } from '../../../Types'
 
 type AnalysisJobTableProps = {
   jobs: any
   analysisId: string
-}
-
-enum JobStatus {
-  STARTING = 'starting',
-  RUNNING = 'running',
-  FAILED = 'failed',
-  COMPLETED = 'completed',
-  UNKNOWN = 'unknown',
 }
 
 const ClickableLabel = styled.div`
@@ -39,10 +31,11 @@ const JobRow = (props: { job: TJob; index: number; analysisId: string }) => {
       })
       .catch((e: Error) => {
         console.error(e)
+        setJobStatus(job.status)
       })
       .finally(() => setLoading(false))
   }, [])
-
+  console.log(jobStatus)
   return (
     <Table.Row
       onClick={() => {
@@ -51,7 +44,9 @@ const JobRow = (props: { job: TJob; index: number; analysisId: string }) => {
       }}
     >
       <Table.Cell>
-        {new Date(job.started).toLocaleString(navigator.language)}
+        {jobStatus !== JobStatus.CREATED
+          ? new Date(job.started).toLocaleString(navigator.language)
+          : 'Not started'}
       </Table.Cell>
       <Table.Cell>{job.triggeredBy}</Table.Cell>
       <Table.Cell>{}</Table.Cell>
@@ -70,6 +65,17 @@ const JobRow = (props: { job: TJob; index: number; analysisId: string }) => {
           </ClickableLabel>
         ) : (
           <>None</>
+        )}
+      </Table.Cell>
+      <Table.Cell>
+        {jobStatus === JobStatus.CREATED ? (
+          <Button variant="ghost_icon">
+            <Icon name="play" title="play" />
+          </Button>
+        ) : (
+          <Button variant="ghost_icon" color="danger">
+            <Icon name="delete_forever" title="delete" />
+          </Button>
         )}
       </Table.Cell>
     </Table.Row>
@@ -92,6 +98,7 @@ const AnalysisJobTable = (props: AnalysisJobTableProps) => {
             <Table.Cell>Duration</Table.Cell>
             <Table.Cell>Status</Table.Cell>
             <Table.Cell>Result</Table.Cell>
+            <Table.Cell>Control</Table.Cell>
           </Table.Row>
         </Table.Head>
         <Table.Body style={{ cursor: 'pointer' }}>

--- a/web/packages/plugins/apps/analysis-platform/src/modules/View.tsx
+++ b/web/packages/plugins/apps/analysis-platform/src/modules/View.tsx
@@ -45,7 +45,6 @@ export const View = ({ settings }: any) => {
         <UIPluginSelector
           absoluteDottedId={`${data_source}/${entity_id}`}
           entity={document}
-          categories={['view']}
           breadcrumb={true}
         />
       )}

--- a/web/packages/plugins/shared/common/src/components/NewEntityButton.tsx
+++ b/web/packages/plugins/shared/common/src/components/NewEntityButton.tsx
@@ -9,18 +9,18 @@ import { AuthContext, DmtAPI, INPUT_FIELD_WIDTH, TReference } from '..'
 import { AxiosError } from 'axios'
 
 export function NewEntityButton(props: {
-  type: string
+  type?: string
   setReference: (r: TReference) => void
 }) {
   const { type, setReference } = props
   const [showScrim, setShowScrim] = useState<boolean>(false)
   const [saveDestination, setSaveDestination] = useState<string>('')
   const [newName, setNewName] = useState<string>('')
-  const [typeToCreate, setTypeToCreate] = useState<string>(type)
+  const [typeToCreate, setTypeToCreate] = useState<string>(type || '')
   const { token } = useContext(AuthContext)
   const dmtAPI = new DmtAPI(token)
 
-  useEffect(() => setTypeToCreate(type), [type])
+  useEffect(() => setTypeToCreate(type || ''), [type])
 
   function addEntityToPath(entity: any): Promise<void> {
     const [dataSource, ...directories] = saveDestination.split('/')

--- a/web/packages/plugins/shared/common/src/components/Pickers/EntityPickerButton.tsx
+++ b/web/packages/plugins/shared/common/src/components/Pickers/EntityPickerButton.tsx
@@ -30,7 +30,7 @@ export const EntityPickerButton = (props: {
       >
         <TreeView
           onSelect={(node: TreeNode) => {
-            if (node.type !== typeFilter) {
+            if (typeFilter && node.type !== typeFilter) {
               NotificationManager.warning('Wrong type')
               return
             }

--- a/web/packages/plugins/shared/common/src/components/UiPluginSelector.tsx
+++ b/web/packages/plugins/shared/common/src/components/UiPluginSelector.tsx
@@ -152,9 +152,10 @@ export function UIPluginSelector(props: {
   // @ts-ignore
   const { loading, getUiPlugin } = useContext(UiPluginContext)
   const { tokenData } = useContext(AuthContext)
-  const roles =
-    [JSON.parse(localStorage.getItem('impersonateRoles') || 'null')] ||
-    tokenData?.roles
+  let roles = tokenData?.roles
+  if (localStorage.getItem('impersonateRoles')) {
+    roles = [JSON.parse(localStorage.getItem('impersonateRoles') || 'null')]
+  }
   const [selectedPlugin, setSelectedPlugin] = useState<number>(0)
   const [selectablePlugins, setSelectablePlugins] = useState<
     TSelectablePlugins[]

--- a/web/packages/plugins/shared/common/src/hooks/useDocument.tsx
+++ b/web/packages/plugins/shared/common/src/hooks/useDocument.tsx
@@ -36,7 +36,7 @@ export function useDocument<T>(
       .finally(() => setLoading(false))
   }, [dataSourceId, documentId])
 
-  function updateDocument(newDocument: T, notify: boolean) {
+  function updateDocument(newDocument: T, notify: boolean): void {
     setLoading(true)
     dmssAPI
       .documentUpdate({

--- a/web/packages/plugins/ui/job-handlers/src/EditContainer.tsx
+++ b/web/packages/plugins/ui/job-handlers/src/EditContainer.tsx
@@ -96,12 +96,7 @@ export const EditContainer = (props: DmtUIPlugin) => {
           {/*</HeaderWrapper>*/}
 
           <div>
-            <Button
-              as="button"
-              onClick={() => {
-                updateDocument(formData, true)
-              }}
-            >
+            <Button as="button" onClick={() => updateDocument(formData, true)}>
               Save
             </Button>
           </div>

--- a/web/packages/plugins/ui/job/src/JobEdit.tsx
+++ b/web/packages/plugins/ui/job/src/JobEdit.tsx
@@ -1,0 +1,168 @@
+import {
+  EntityPickerButton,
+  INPUT_FIELD_WIDTH,
+  JobHandlerPicker,
+  NewEntityButton,
+  TReference,
+  UIPluginSelector,
+} from '@dmt/common'
+import * as React from 'react'
+import { useState } from 'react'
+import { Button, Input, Label, Typography } from '@equinor/eds-core-react'
+import styled from 'styled-components'
+import { JobStatus, TJob } from './types'
+
+const Column = styled.div``
+
+const GroupWrapper = styled.div`
+  & > * {
+    padding-top: 8px;
+  }
+`
+
+const HeaderWrapper = styled.div`
+  margin-bottom: 50px;
+  margin-top: 8px;
+`
+
+export const JobEdit = (props: {
+  document: TJob
+  updateDocument: Function
+  documentId: string
+  dataSourceId: string
+}) => {
+  const { document, documentId, dataSourceId, updateDocument } = props
+
+  const [formData, setFormData] = useState<TJob>({ ...document })
+  if (document.status !== JobStatus.CREATED) {
+    return (
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '30px',
+        }}
+      >
+        <h4>Can't edit job parameters after job has been started</h4>
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <div style={{ marginBottom: '10px' }}>
+        <HeaderWrapper>
+          <Typography variant="h3">Input</Typography>
+          <GroupWrapper>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'flex-end',
+              }}
+            >
+              <Column>
+                <Label label={'Input entity'} />
+                <Input
+                  style={{ cursor: 'pointer', width: INPUT_FIELD_WIDTH }}
+                  type="string"
+                  value={
+                    formData?.applicationInput?.name ||
+                    formData?.applicationInput?._id ||
+                    ''
+                  }
+                  placeholder={
+                    formData?.applicationInput?.name || 'Select or create'
+                  }
+                />
+              </Column>
+              <EntityPickerButton
+                onChange={(selectedEntity: any) => {
+                  setFormData({
+                    ...formData,
+                    applicationInput: selectedEntity,
+                  })
+                }}
+              />
+              <NewEntityButton
+                setReference={(createdEntity: TReference) => {
+                  setFormData({
+                    ...formData,
+                    applicationInput: createdEntity,
+                  })
+                }}
+              />
+            </div>
+            <div
+              style={{
+                margin: '10px 20px',
+                borderLeft: '2px solid grey',
+                paddingLeft: '10px',
+              }}
+            >
+              <UIPluginSelector
+                entity={formData.applicationInput}
+                absoluteDottedId={`${dataSourceId}/${formData.applicationInput._id}`}
+                categories={['container']}
+              />
+            </div>
+          </GroupWrapper>
+        </HeaderWrapper>
+
+        <HeaderWrapper>
+          <Typography variant="h3">Job runner</Typography>
+          <GroupWrapper>
+            <Column>
+              <Label label={'Blueprint'} />
+              <JobHandlerPicker
+                onChange={(selectedBlueprint: string) =>
+                  setFormData({
+                    ...formData,
+                    runner: { ...formData?.runner, type: selectedBlueprint },
+                  })
+                }
+                formData={formData?.runner?.type || ''}
+              />
+              <div
+                style={{
+                  margin: '10px 20px',
+                  borderLeft: '2px solid grey',
+                  paddingLeft: '10px',
+                }}
+              >
+                <UIPluginSelector
+                  absoluteDottedId={`${dataSourceId}/${documentId}.runner`}
+                  entity={
+                    (Object.keys(formData?.runner).length &&
+                      formData.runner) || { type: '' }
+                  }
+                  breadcrumb={false}
+                  categories={['edit']}
+                />
+              </div>
+            </Column>
+          </GroupWrapper>
+        </HeaderWrapper>
+
+        <div style={{ justifyContent: 'space-around', display: 'flex' }}>
+          <Button
+            as="button"
+            variant="outlined"
+            color="danger"
+            onClick={() => setFormData({ ...document })}
+          >
+            Reset
+          </Button>
+          <Button
+            as="button"
+            onClick={() => {
+              updateDocument(formData, true)
+            }}
+          >
+            Save
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/packages/plugins/ui/job/src/index.tsx
+++ b/web/packages/plugins/ui/job/src/index.tsx
@@ -1,23 +1,58 @@
 import * as React from 'react'
 
 import { DmtPluginType, DmtUIPlugin, useDocument } from '@dmt/common'
-import { JobLog } from './Job'
+import { JobControl } from './JobControl'
+import { TJob } from './types'
+import { JobEdit } from './JobEdit'
 
-const PluginComponent = (props: DmtUIPlugin) => {
+const JobControlWrapper = (props: DmtUIPlugin) => {
   const { documentId, dataSourceId } = props
-  const [document, documentLoading, updateDocument, error] = useDocument(
+  const [document, documentLoading, updateDocument, error] = useDocument<TJob>(
     dataSourceId,
     documentId,
     false
   )
   if (documentLoading) return <div>Loading...</div>
-  return <JobLog document={document} jobId={`${dataSourceId}/${documentId}`} />
+  if (error) return <div>Something went wrong; {error}</div>
+  if (!document) return <div>The job document is empty</div>
+  return (
+    <JobControl
+      document={document}
+      jobId={`${dataSourceId}/${documentId}`}
+      updateDocument={updateDocument}
+    />
+  )
+}
+
+const JobEditWrapper = (props: DmtUIPlugin) => {
+  const { documentId, dataSourceId, onOpen } = props
+  const [document, documentLoading, updateDocument, error] = useDocument<TJob>(
+    dataSourceId,
+    documentId,
+    false
+  )
+  if (documentLoading) return <div>Loading...</div>
+  if (error) return <div>Something went wrong; {error}</div>
+  if (!document) return <div>The job document is empty</div>
+  return (
+    <JobEdit
+      document={document}
+      dataSourceId={dataSourceId}
+      documentId={documentId}
+      updateDocument={updateDocument}
+    />
+  )
 }
 
 export const plugins: any = [
   {
-    pluginName: 'job',
+    pluginName: 'jobControl',
     pluginType: DmtPluginType.UI,
-    component: PluginComponent,
+    component: JobControlWrapper,
+  },
+  {
+    pluginName: 'jobEdit',
+    pluginType: DmtPluginType.UI,
+    component: JobEditWrapper,
   },
 ]

--- a/web/packages/plugins/ui/job/src/types.ts
+++ b/web/packages/plugins/ui/job/src/types.ts
@@ -1,0 +1,25 @@
+import { TReference } from '@dmt/common'
+
+export enum JobStatus {
+  CREATED = 'created',
+  STARTING = 'starting',
+  RUNNING = 'running',
+  FAILED = 'failed',
+  COMPLETED = 'completed',
+  UNKNOWN = 'unknown',
+}
+
+export type TJob = {
+  label: string
+  name: string
+  type: string
+  status: JobStatus
+  triggeredBy: string
+  applicationInput: TReference
+  runner?: any
+  started: string
+  result?: any
+  ended?: string
+  outputTarget?: string
+  referenceTarget?: string
+}

--- a/web/packages/plugins/ui/sima-application-input/src/EditSimaApplicationInput.tsx
+++ b/web/packages/plugins/ui/sima-application-input/src/EditSimaApplicationInput.tsx
@@ -11,7 +11,7 @@ import {
   useDocument,
 } from '@dmt/common'
 import * as React from 'react'
-import { ChangeEvent, useState } from 'react'
+import { ChangeEvent, useEffect, useState } from 'react'
 import {
   Input,
   Label,
@@ -50,6 +50,11 @@ export const EditSimaApplicationInput = (props: DmtUIPlugin) => {
     false
   )
 
+  useEffect(() => {
+    if (!_document) return
+    setFormData(_document)
+  }, [_document])
+
   function getNewSTaskBody(filename: string): any {
     return {
       type: 'AnalysisPlatformDS/Blueprints/STask',
@@ -63,7 +68,12 @@ export const EditSimaApplicationInput = (props: DmtUIPlugin) => {
 
   return (
     <div
-      style={{ display: 'flex', alignItems: 'left', flexDirection: 'column' }}
+      style={{
+        display: 'flex',
+        alignItems: 'left',
+        flexDirection: 'column',
+        margin: '10px 20px',
+      }}
     >
       <div style={{ marginBottom: '10px' }}>
         <HeaderWrapper>


### PR DESCRIPTION
## What does this pull request change?
- Rework of how users create, edit and start jobs
- "Run analysis" button now only append jobs to the analysis jobs list
- A new plugin "EditJob" that can be used to edit the job before starting it.
- Renamed "Job" plugin to "JobControl", and added "Start job" button

## Issues related to this change

closes #1211 