### PR TITLE
Bugfix/analysis in web not updated

### DIFF
--- a/web/packages/plugins/apps/analysis-platform/src/modules/View.tsx
+++ b/web/packages/plugins/apps/analysis-platform/src/modules/View.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 // @ts-ignore
 import { useParams } from 'react-router-dom'
 import { useDocument, UIPluginSelector } from '@dmt/common'
@@ -17,6 +17,7 @@ export const View = ({ settings }: any) => {
     documentLoading,
     setDocument,
     error,
+    fetchDocument,
   ] = useDocument<TValidEntity>(data_source, entity_id, true)
 
   if (error)
@@ -39,6 +40,9 @@ export const View = ({ settings }: any) => {
           absoluteDottedId={`${data_source}/${entity_id}`}
           entity={document}
           breadcrumb={true}
+          onSubmit={() => {
+            fetchDocument()
+          }}
         />
       )}
     </>

--- a/web/packages/plugins/ui/analysis/src/OperatorView.tsx
+++ b/web/packages/plugins/ui/analysis/src/OperatorView.tsx
@@ -3,13 +3,18 @@ import { DmtUIPlugin, UIPluginSelector, TJob } from '@dmt/common'
 import { AnalysisInfoCard, AnalysisJobTable } from './components'
 
 export const OperatorView = (props: DmtUIPlugin): JSX.Element => {
-  const { document: analysis, dataSourceId } = props
+  const { document: analysis, dataSourceId, onSubmit } = props
   const [jobs, setJobs] = useState<any[]>([])
 
   useEffect(() => {
     if (!analysis) return
     setJobs(analysis.jobs)
   }, [analysis])
+  if (!onSubmit) {
+    throw new Error(
+      'OperatorView plugin must have an onSubmit function as props'
+    )
+  }
 
   return (
     <>
@@ -24,6 +29,9 @@ export const OperatorView = (props: DmtUIPlugin): JSX.Element => {
           entity={analysis.task}
           absoluteDottedId={`${dataSourceId}/${analysis._id}.task`}
           categories={['container']}
+          onSubmit={() => {
+            onSubmit()
+          }}
         />
         <AnalysisJobTable
           jobs={jobs}

--- a/web/packages/plugins/ui/job-handlers/src/EditContainer.tsx
+++ b/web/packages/plugins/ui/job-handlers/src/EditContainer.tsx
@@ -29,7 +29,7 @@ const HeaderWrapper = styled.div`
 `
 
 export const EditContainer = (props: DmtUIPlugin) => {
-  const { document, dataSourceId, documentId } = props
+  const { document, dataSourceId, documentId, onSubmit } = props
   const [formData, setFormData] = useState<any>({ ...document })
   const [_document, loading, updateDocument] = useDocument(
     dataSourceId,
@@ -69,7 +69,11 @@ export const EditContainer = (props: DmtUIPlugin) => {
       </div>
     )
   }
-
+  if (!onSubmit) {
+    throw new Error(
+      'EditContainer plugin must have an onSubmit function as props'
+    )
+  }
   return (
     <div
       style={{
@@ -142,7 +146,7 @@ export const EditContainer = (props: DmtUIPlugin) => {
             ) : (
               <Button
                 as="button"
-                onClick={() => updateDocument(formData, true)}
+                onClick={() => updateDocument(formData, true, onSubmit)}
               >
                 Save
               </Button>

--- a/web/packages/plugins/ui/job/src/JobEdit.tsx
+++ b/web/packages/plugins/ui/job/src/JobEdit.tsx
@@ -31,8 +31,9 @@ export const JobEdit = (props: {
   updateDocument: Function
   documentId: string
   dataSourceId: string
+  onSubmit: Function
 }) => {
-  const { document, documentId, dataSourceId, updateDocument } = props
+  const { document, documentId, dataSourceId, updateDocument, onSubmit } = props
 
   const [formData, setFormData] = useState<TJob>({ ...document })
   if (document.status !== EJobStatus.CREATED) {
@@ -105,6 +106,7 @@ export const JobEdit = (props: {
                 entity={formData.applicationInput}
                 absoluteDottedId={`${dataSourceId}/${formData.applicationInput._id}`}
                 categories={['container']}
+                onSubmit={onSubmit}
               />
             </div>
           </GroupWrapper>
@@ -136,6 +138,7 @@ export const JobEdit = (props: {
                   entity={formData.runner}
                   breadcrumb={false}
                   categories={['edit']}
+                  onSubmit={onSubmit}
                 />
               </div>
             </Column>
@@ -154,7 +157,7 @@ export const JobEdit = (props: {
           <Button
             as="button"
             onClick={() => {
-              updateDocument(formData, true)
+              updateDocument(formData, true) //Todo do i need onsubmit as extra param??
             }}
           >
             Save

--- a/web/packages/plugins/ui/job/src/index.tsx
+++ b/web/packages/plugins/ui/job/src/index.tsx
@@ -25,11 +25,13 @@ const JobControlWrapper = (props: DmtUIPlugin) => {
 
 const JobEditWrapper = (props: DmtUIPlugin) => {
   const { documentId, dataSourceId, onOpen } = props
-  const [document, documentLoading, updateDocument, error] = useDocument<TJob>(
-    dataSourceId,
-    documentId,
-    false
-  )
+  const [
+    document,
+    documentLoading,
+    updateDocument,
+    error,
+    fetchDocument,
+  ] = useDocument<TJob>(dataSourceId, documentId, false)
   if (documentLoading) return <div>Loading...</div>
   if (error) return <div>Something went wrong; {error}</div>
   if (!document) return <div>The job document is empty</div>
@@ -39,6 +41,7 @@ const JobEditWrapper = (props: DmtUIPlugin) => {
       dataSourceId={dataSourceId}
       documentId={documentId}
       updateDocument={updateDocument}
+      onSubmit={fetchDocument}
     />
   )
 }

--- a/web/packages/plugins/ui/simpos-ui/src/simpos/rao/forms/RAOSceForm.tsx
+++ b/web/packages/plugins/ui/simpos-ui/src/simpos/rao/forms/RAOSceForm.tsx
@@ -8,7 +8,7 @@ import { RAOSceForm } from './raoSce.js'
 const RAOSceForm_Component = (props: DmtUIPlugin) => {
   const { dataSourceId, documentId, updateDocument } = props
 
-  const [document, isLoading, hasError] = useDocument(
+  const [document, isLoading, setDocument, hasError] = useDocument(
     dataSourceId,
     documentId,
     true

--- a/web/packages/plugins/ui/tabs/src/TabsContainer.tsx
+++ b/web/packages/plugins/ui/tabs/src/TabsContainer.tsx
@@ -51,7 +51,7 @@ type TStringMap = {
 }
 
 export const TabsContainer = (props: DmtUIPlugin) => {
-  const { documentId, dataSourceId, config, document } = props
+  const { documentId, dataSourceId, config, document, onSubmit } = props
   const [selectedTab, setSelectedTab] = useState<string>('home')
   const [formData, setFormData] = useState<any>({})
   const [childTabs, setChildTabs] = useState<TStringMap>({})
@@ -72,7 +72,11 @@ export const TabsContainer = (props: DmtUIPlugin) => {
     setChildTabs({ ...childTabs, [tabData.attribute]: tabData })
     setSelectedTab(tabData.attribute)
   }
-
+  if (!onSubmit) {
+    throw new Error(
+      'TabsContainer plugin must have an onSubmit function as props'
+    )
+  }
   return (
     <TabsProvider onOpen={handleOpen}>
       <div style={{ display: 'flex', flexDirection: 'column' }}>
@@ -120,6 +124,9 @@ export const TabsContainer = (props: DmtUIPlugin) => {
               setChildTabs({ ...childTabs, [tabData.attribute]: tabData })
               setSelectedTab(tabData.attribute)
             }}
+            onSubmit={() => {
+              onSubmit()
+            }}
           />
         </HidableWrapper>
         {Object.values(childTabs).map((childTab: any) => {
@@ -130,6 +137,9 @@ export const TabsContainer = (props: DmtUIPlugin) => {
                 key={childTab.attribute}
                 absoluteDottedId={childTab.absoluteDottedId}
                 entity={childTab.entity}
+                onSubmit={() => {
+                  onSubmit()
+                }}
                 categories={childTab.categories}
               />
             </HidableWrapper>

--- a/web/packages/plugins/ui/task/src/EditTask.tsx
+++ b/web/packages/plugins/ui/task/src/EditTask.tsx
@@ -28,7 +28,7 @@ const HeaderWrapper = styled.div`
 `
 
 export const EditTask = (props: DmtUIPlugin) => {
-  const { document, documentId, dataSourceId, onOpen } = props
+  const { document, documentId, dataSourceId, onOpen, onSubmit } = props
   const [_document, _loading, updateDocument, error] = useDocument<any>(
     dataSourceId,
     documentId,
@@ -41,6 +41,12 @@ export const EditTask = (props: DmtUIPlugin) => {
     // onChange is an indicator if the plugin is used within another plugin. If so, don't override formData
     setFormData({ ..._document })
   }, [_document])
+
+  if (!onSubmit) {
+    throw new Error(
+      'EditTask UI plugin must have an onSubmit function as props'
+    )
+  }
 
   return (
     <div>
@@ -173,6 +179,7 @@ export const EditTask = (props: DmtUIPlugin) => {
                     entity={formData.runner}
                     breadcrumb={false}
                     categories={['edit']}
+                    onSubmit={() => onSubmit()}
                   />
                 )}
               </div>
@@ -192,7 +199,7 @@ export const EditTask = (props: DmtUIPlugin) => {
           <Button
             as="button"
             onClick={() => {
-              updateDocument(formData, true)
+              updateDocument(formData, true, onSubmit)
             }}
           >
             Save

--- a/web/packages/plugins/ui/task/src/SIMAInputOnly.tsx
+++ b/web/packages/plugins/ui/task/src/SIMAInputOnly.tsx
@@ -2,9 +2,14 @@ import { DmtUIPlugin, UIPluginSelector } from '@dmt/common'
 import * as React from 'react'
 
 export const EditSIMAInput = (props: DmtUIPlugin) => {
-  const { document, documentId, dataSourceId } = props
+  const { document, documentId, dataSourceId, onSubmit } = props
   if (!document?.applicationInput?.input) {
     return <pre style={{ color: 'red' }}>No input exists for the analysis</pre>
+  }
+  if (!onSubmit) {
+    throw new Error(
+      'EditSIMAInput UI plugin must have an onSubmit function as props'
+    )
   }
   return (
     <div>
@@ -12,6 +17,7 @@ export const EditSIMAInput = (props: DmtUIPlugin) => {
         absoluteDottedId={`${dataSourceId}/${documentId}.applicationInput.input`}
         entity={document?.applicationInput?.input}
         categories={['edit']}
+        onSubmit={() => onSubmit()}
       />
     </div>
   )


### PR DESCRIPTION
## What does this pull request change?
* use onSubmit in UIPluginSelector, to make sure that the analysis document in View.tsx (which is used when creating a new job) is always up to date with the dataabase
* new function fetchDocument in the useDocument hook to be able to fetch the newest version of the document from the database
* add an extra optional parameter "functionToRunAfterUpdate" to the updateDocument() in useDocument. This makes it possible to know run functions after a database update is completed. Which is useful for knowing when to fetch a new version of a document.

## Why is this pull request needed?
bugfix
## Issues related to this change
closes #1217 
