### PR TITLE
Inspector view

### DIFF
--- a/web/packages/plugins/shared/common/src/components/Header.tsx
+++ b/web/packages/plugins/shared/common/src/components/Header.tsx
@@ -11,6 +11,7 @@ import {
   sortApplications,
   useLocalStorage,
 } from '../index'
+import { APP_ROLES } from '../utils/appRoles'
 // @ts-ignore
 import { NotificationManager } from 'react-notifications'
 import axios, { AxiosResponse } from 'axios'
@@ -210,13 +211,7 @@ export const Header = (props: {
             <>
               <p>Impersonate a role (UI only)</p>
               <UnstyledList>
-                {[
-                  'dmss-admin',
-                  'operator',
-                  'expert-operator',
-                  'domain-expert',
-                  'domain-developer',
-                ].map((role: string) => (
+                {APP_ROLES.map((role: string) => (
                   <li key={role}>
                     <Radio
                       label={role}

--- a/web/packages/plugins/shared/common/src/utils/appRoles.tsx
+++ b/web/packages/plugins/shared/common/src/utils/appRoles.tsx
@@ -6,13 +6,13 @@ export const APP_ROLES: string[] = [
   'domain-expert',
   'domain-developer',
 ]
-export const EXPERT_ROLES = [
+export const EXPERT_ROLES: string[] = [
   'expert-operator',
   'domain-developer',
   'domain-expert',
   'dmss-admin',
 ]
-export const OPERATOR_ROLES = EXPERT_ROLES.concat(['operator'])
+export const OPERATOR_ROLES: string[] = EXPERT_ROLES.concat(['operator'])
 
 export function getRoles(tokenData: any): string[] {
   /**

--- a/web/packages/plugins/shared/common/src/utils/appRoles.tsx
+++ b/web/packages/plugins/shared/common/src/utils/appRoles.tsx
@@ -1,17 +1,26 @@
-const EXPERT_ROLES = [
+export const APP_ROLES: string[] = [
+  'dmss-admin',
+  'inspector',
+  'operator',
+  'expert-operator',
+  'domain-expert',
+  'domain-developer',
+]
+export const EXPERT_ROLES = [
   'expert-operator',
   'domain-developer',
   'domain-expert',
   'dmss-admin',
 ]
+export const OPERATOR_ROLES = EXPERT_ROLES.concat(['operator'])
 
-export function getRoles(userData: any): string[] {
+export function getRoles(tokenData: any): string[] {
   /**
-   * Retrieve the user's roles from userData,
+   * Retrieve the user's roles from tokenData,
    * overriding with impersonated roles if present
    */
   // Get roles from token
-  let roles = userData?.roles || []
+  let roles = tokenData?.roles || []
   // Check for impersonated roles
   if (localStorage.getItem('impersonateRoles')) {
     roles = [JSON.parse(localStorage.getItem('impersonateRoles') || 'null')]
@@ -19,13 +28,32 @@ export function getRoles(userData: any): string[] {
   return roles
 }
 
-export function hasExpertRole(userData: any): boolean {
+export function hasExpertRole(tokenData: any): boolean {
+  /**
+   * Check whether the user's token has an expert role
+   * Accounts for any impersonated roles
+   */
   // Always return true if auth is not enabled
   if (process.env.REACT_APP_AUTH !== '1') return true
-  const roles = getRoles(userData)
+  const roles = getRoles(tokenData)
   if (roles) {
     // If any of the roles the user has in the the EXPERT_ROLES array, return TRUE
     return roles.some((role: string) => EXPERT_ROLES.includes(role))
+  }
+  return false
+}
+
+export function hasOperatorRole(tokenData: any): boolean {
+  /**
+   * Check whether the user's token has an operator role (i.e. 'operator' or one of the expert roles)
+   * Accounts for any impersonated roles
+   */
+  // Always return true if auth is not enabled
+  if (process.env.REACT_APP_AUTH !== '1') return true
+  const roles = getRoles(tokenData)
+  if (roles) {
+    // If any of the roles the user has in the the OPERATOR_ROLES array, return TRUE
+    return roles.some((role: string) => OPERATOR_ROLES.includes(role))
   }
   return false
 }

--- a/web/packages/plugins/ui/analysis/src/components/AnalysisCard.tsx
+++ b/web/packages/plugins/ui/analysis/src/components/AnalysisCard.tsx
@@ -18,6 +18,7 @@ import {
   EJobStatus,
   TJob,
   EBlueprint,
+  hasOperatorRole,
 } from '@dmt/common'
 import { TAnalysis, TTask } from '../Types'
 import { TAnalysisCardProps } from '../Types'
@@ -154,35 +155,37 @@ const AnalysisCard = (props: TAnalysisCardProps) => {
             </FlexWrapper>
           </div>
         </div>
-        <Card.Actions>
-          {'task' in analysis && Object.keys(analysis.task).length > 0 && (
-            <>
-              <RunAnalysisButton
-                analysis={analysis}
-                addJob={addJob}
-                jobs={jobs}
-                dataSourceId={dataSourceId}
-              />
-              {hasExpertRole(tokenData) && (
-                <Tooltip title={'Not implemented'}>
-                  <Button style={{ width: 'max-content' }} disabled>
-                    Configure schedule
-                    <Icons name="time" title="time" />
-                  </Button>
-                </Tooltip>
-              )}
-            </>
-          )}
-          {hasExpertRole(tokenData) && (
-            <Button
-              onClick={() => setViewACL(!viewACL)}
-              style={{ width: 'max-content' }}
-            >
-              Access control
-              <Icons name="assignment_user" title="assignment_user" />
-            </Button>
-          )}
-        </Card.Actions>
+        {hasOperatorRole(tokenData) && (
+          <Card.Actions>
+            {'task' in analysis && Object.keys(analysis.task).length > 0 && (
+              <>
+                <RunAnalysisButton
+                  analysis={analysis}
+                  addJob={addJob}
+                  jobs={jobs}
+                  dataSourceId={dataSourceId}
+                />
+                {hasExpertRole(tokenData) && (
+                  <Tooltip title={'Not implemented'}>
+                    <Button style={{ width: 'max-content' }} disabled>
+                      Configure schedule
+                      <Icons name="time" title="time" />
+                    </Button>
+                  </Tooltip>
+                )}
+              </>
+            )}
+            {hasExpertRole(tokenData) && (
+              <Button
+                onClick={() => setViewACL(!viewACL)}
+                style={{ width: 'max-content' }}
+              >
+                Access control
+                <Icons name="assignment_user" title="assignment_user" />
+              </Button>
+            )}
+          </Card.Actions>
+        )}
       </Card>
       <Dialog
         isOpen={viewACL}


### PR DESCRIPTION
## What does this pull request change?
- Adds an additional role to the 'impersonate role' selector; `inspector`
- Uses the `InspectorView.tsx` view for users with the `inspector` role
- Defines all roles in single file; `appRoles.tsx`
  - `APP_ROLES`: All possible roles in the app
  - `EXPERT_ROLES`: All `expert` roles
  - `OPERATOR_ROLES`: All `expert` roles, as well as the role `operator`
- Adds a function, `hasOperatorRole()`, to `appRoles.tsx`
- Hides the "controls" (run, delete) in `AnalysisJobTable.tsx` for non-operators (inspector)
- Links directly to a result, rather than a job, for non-operators (inspector)
- Hides the "New job" action for non-operators

## Why is this pull request needed?
- To enable a simplified view for the `inspector` role

## Issues related to this change
- Resolves #1256 
