### PR TITLE
Operator analysis view improvements

### DIFF
--- a/web/packages/plugins/shared/common/src/components/Header.tsx
+++ b/web/packages/plugins/shared/common/src/components/Header.tsx
@@ -11,7 +11,7 @@ import {
   sortApplications,
   useLocalStorage,
 } from '../index'
-import { APP_ROLES } from '../utils/appRoles'
+import { APP_ROLES, DMSS_ADMIN_ROLE } from '../utils/appRoles'
 // @ts-ignore
 import { NotificationManager } from 'react-notifications'
 import axios, { AxiosResponse } from 'axios'
@@ -207,7 +207,7 @@ export const Header = (props: {
           </div>
           {apiKey && <pre>{apiKey}</pre>}
 
-          {tokenData?.roles.includes('dmss-admin') && (
+          {tokenData?.roles.includes(DMSS_ADMIN_ROLE) && (
             <>
               <p>Impersonate a role (UI only)</p>
               <UnstyledList>

--- a/web/packages/plugins/shared/common/src/utils/appRoles.tsx
+++ b/web/packages/plugins/shared/common/src/utils/appRoles.tsx
@@ -1,18 +1,17 @@
-export const APP_ROLES: string[] = [
-  'dmss-admin',
-  'inspector',
-  'operator',
-  'expert-operator',
-  'domain-expert',
-  'domain-developer',
-]
-export const EXPERT_ROLES: string[] = [
-  'expert-operator',
+export const DMSS_ADMIN_ROLE: string = 'dmss-admin'
+export const INSPECTOR_ROLE: string = 'inspector'
+// Domain roles
+export const DOMAIN_ROLES: string[] = [
   'domain-developer',
   'domain-expert',
-  'dmss-admin',
+  DMSS_ADMIN_ROLE,
 ]
-export const OPERATOR_ROLES: string[] = EXPERT_ROLES.concat(['operator'])
+// Expert roles: Includes domain roles
+export const EXPERT_ROLES: string[] = ['expert-operator', ...DOMAIN_ROLES]
+// Operator roles: Includes expert roles
+export const OPERATOR_ROLES: string[] = ['operator', ...EXPERT_ROLES]
+// All roles
+export const APP_ROLES: string[] = [INSPECTOR_ROLE, ...OPERATOR_ROLES]
 
 export function getRoles(tokenData: any): string[] {
   /**
@@ -37,7 +36,7 @@ export function hasExpertRole(tokenData: any): boolean {
   if (process.env.REACT_APP_AUTH !== '1') return true
   const roles = getRoles(tokenData)
   if (roles) {
-    // If any of the roles the user has in the the EXPERT_ROLES array, return TRUE
+    // If any of the roles the user has are in the EXPERT_ROLES array, return TRUE
     return roles.some((role: string) => EXPERT_ROLES.includes(role))
   }
   return false
@@ -52,8 +51,23 @@ export function hasOperatorRole(tokenData: any): boolean {
   if (process.env.REACT_APP_AUTH !== '1') return true
   const roles = getRoles(tokenData)
   if (roles) {
-    // If any of the roles the user has in the the OPERATOR_ROLES array, return TRUE
+    // If any of the roles the user has are in the OPERATOR_ROLES array, return TRUE
     return roles.some((role: string) => OPERATOR_ROLES.includes(role))
+  }
+  return false
+}
+
+export function hasDomainRole(tokenData: any): boolean {
+  /**
+   * Check whether the user's token has a 'domain' role
+   * Accounts for any impersonated roles
+   */
+  // Always return true if auth is not enabled
+  if (process.env.REACT_APP_AUTH !== '1') return true
+  const roles = getRoles(tokenData)
+  if (roles) {
+    // If any of the roles the user has are in the DOMAIN_ROLES array, return TRUE
+    return roles.some((role: string) => DOMAIN_ROLES.includes(role))
   }
   return false
 }

--- a/web/packages/plugins/ui/analysis/src/OperatorView.tsx
+++ b/web/packages/plugins/ui/analysis/src/OperatorView.tsx
@@ -1,11 +1,14 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useContext } from 'react'
 import { DmtUIPlugin, UIPluginSelector, TJob } from '@dmt/common'
 import { AnalysisInfoCard, AnalysisJobTable } from './components'
+import { hasDomainRole } from '@dmt/common'
+import { AuthContext } from 'react-oauth2-code-pkce'
 
 export const OperatorView = (props: DmtUIPlugin): JSX.Element => {
   const { document, dataSourceId } = props
   const [jobs, setJobs] = useState<any[]>([])
   const [analysis, setAnalysis] = useState<any>(document)
+  const { tokenData } = useContext(AuthContext)
 
   useEffect(() => {
     if (!analysis) return
@@ -26,14 +29,16 @@ export const OperatorView = (props: DmtUIPlugin): JSX.Element => {
         dataSourceId={dataSourceId}
       />
       <>
-        <UIPluginSelector
-          entity={analysis.task}
-          absoluteDottedId={`${dataSourceId}/${analysis._id}.task`}
-          categories={['container']}
-          onSubmit={(formData: any) => {
-            setAnalysis({ ...analysis, task: formData })
-          }}
-        />
+        {hasDomainRole(tokenData) && (
+          <UIPluginSelector
+            entity={analysis.task}
+            absoluteDottedId={`${dataSourceId}/${analysis._id}.task`}
+            categories={['container']}
+            onSubmit={(formData: any) => {
+              setAnalysis({ ...analysis, task: formData })
+            }}
+          />
+        )}
         <AnalysisJobTable
           jobs={jobs}
           analysisId={analysis._id}


### PR DESCRIPTION
## What does this pull request change?
- Improves `appRoles.tsx` definitions to avoid duplicate entries
- Hides "default task edit" for non-domain roles (i.e. displayed only for domain-experts and domain-developers)
- Adds a role check util for "domain" users

## Why is this pull request needed?

## Issues related to this change
- Resolves #1266 

