### PR TITLE
set correct type when initializing tree

### DIFF
--- a/web/packages/plugins/shared/common/src/domain/Tree.tsx
+++ b/web/packages/plugins/shared/common/src/domain/Tree.tsx
@@ -127,7 +127,9 @@ export class TreeNode {
     this.isDataSource = isDataSource
     this.entity = entity
     this.name = name || entity?.name
-    this.type = attribute.attributeType
+    this.type = Object.keys(entity).length
+      ? entity.type
+      : attribute.attributeType
     this.attribute = attribute
     this.children = children
   }


### PR DESCRIPTION
## What does this pull request change?
Initialize the tree correctly - added filter such that only folders in a root package are added to initial tree, instead of all content inside root package. (This caused TreeNode children of type system/SIMOS/Blueprint to be initialized with wrong values)
## Why is this pull request needed?

## Issues related to this change
closes #1263 
