### PR TITLE
fix: correctly show list of blueprint attributes

### DIFF
--- a/web/packages/plugins/ui/blueprint/src/EditBlueprint.tsx
+++ b/web/packages/plugins/ui/blueprint/src/EditBlueprint.tsx
@@ -252,7 +252,7 @@ export const EditBlueprint = (props: DmtUIPlugin) => {
       <Spacer />
       <Label label="Attributes" />
       <Accordion>
-        {Array.isArray(formData?.attribute) &&
+        {Array.isArray(formData?.attributes) &&
           formData.attributes.map((attribute: any, index: number) => (
             <Accordion.Item key={index}>
               <Accordion.Header>


### PR DESCRIPTION
## What does this pull request change?

* Attributes not shown bug

## Why is this pull request needed?

Fixes this problem, that the list of blueprint attributes are not shown:

<img width="817" alt="image" src="https://user-images.githubusercontent.com/1190419/173636934-aace0d15-e35f-4f4d-a94b-51f28277b82a.png">

## Issues related to this change

