### PR TITLE
add DestinationPicker to EditTask.tsx, and update NewEntityButton.tsx functionality

### DIFF
--- a/web/packages/plugins/shared/common/src/components/NewEntityButton.tsx
+++ b/web/packages/plugins/shared/common/src/components/NewEntityButton.tsx
@@ -15,10 +15,14 @@ import { AxiosError } from 'axios'
 export function NewEntityButton(props: {
   type?: string
   setReference: (r: TReference) => void
+  defaultDestination?: string
 }) {
-  const { type, setReference } = props
+  const { type, setReference, defaultDestination } = props
   const [showScrim, setShowScrim] = useState<boolean>(false)
-  const [saveDestination, setSaveDestination] = useState<string>('')
+  const [saveDestination, setSaveDestination] = useState<string>(
+    defaultDestination ? defaultDestination : ''
+  )
+
   const [newName, setNewName] = useState<string>('')
   const [copyTarget, setCopyTarget] = useState<TReference | undefined>(
     undefined
@@ -29,6 +33,11 @@ export function NewEntityButton(props: {
   const dmtAPI = new DmtAPI(token)
 
   useEffect(() => setTypeToCreate(type || ''), [type])
+  useEffect(() => {
+    if (defaultDestination) {
+      setSaveDestination(defaultDestination)
+    }
+  }, [defaultDestination])
 
   function addEntityToPath(entity: any): Promise<void> {
     const [dataSource, ...directories] = saveDestination.split('/')
@@ -66,15 +75,10 @@ export function NewEntityButton(props: {
             minHeight: '270px',
           }}
         >
-          <Label label={'Folder'} />
-          <DestinationPicker
-            onChange={(value: any) => setSaveDestination(value)}
-            formData={saveDestination}
-          />
           <div style={{ display: 'block' }}>
             <Label label={'Blueprint'} />
             <BlueprintPicker
-              disabled={!!copyTarget}
+              disabled={!!copyTarget || !!type}
               onChange={(selectedType: string) => setTypeToCreate(selectedType)}
               formData={typeToCreate}
             />
@@ -83,6 +87,16 @@ export function NewEntityButton(props: {
                 style={{ marginLeft: '40px' }}
               >{`Copying entity named '${copyTarget.name}'`}</div>
             )}
+          </div>
+          <div>
+            <Label label={'Entity destination folder'} />
+            <DestinationPicker
+              onChange={(selectedFolder: string) =>
+                setSaveDestination(selectedFolder)
+              }
+              disabled={!!defaultDestination}
+              formData={saveDestination}
+            />
           </div>
           <Label label={'Name'} />
           <Input
@@ -106,6 +120,7 @@ export function NewEntityButton(props: {
             {!copyTarget ? (
               <EntityPickerButton
                 variant="outlined"
+                typeFilter={typeToCreate}
                 text="Copy existing"
                 onChange={(ref: TReference) => setCopyTarget(ref)}
               />

--- a/web/packages/plugins/shared/common/src/components/NewEntityButton.tsx
+++ b/web/packages/plugins/shared/common/src/components/NewEntityButton.tsx
@@ -78,7 +78,7 @@ export function NewEntityButton(props: {
         height={'370px'}
       >
         <DialogWrapper>
-          {!!!type && (
+          {!type && (
             <div style={{ display: 'block' }}>
               <Label label={'Blueprint'} />
               <BlueprintPicker
@@ -91,7 +91,7 @@ export function NewEntityButton(props: {
             </div>
           )}
 
-          {!!!defaultDestination && (
+          {!defaultDestination && (
             <div>
               <Label label={'Entity destination folder'} />
               <DestinationPicker

--- a/web/packages/plugins/shared/common/src/components/NewEntityButton.tsx
+++ b/web/packages/plugins/shared/common/src/components/NewEntityButton.tsx
@@ -11,6 +11,17 @@ import {
 import { addToPath } from './UploadFileButton'
 import { AuthContext, DmssAPI, DmtAPI, INPUT_FIELD_WIDTH, TReference } from '..'
 import { AxiosError } from 'axios'
+import styled from 'styled-components'
+
+const DialogWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justifycontent: space-between;
+  margin: 20px;
+  & > * {
+    padding-top: 8px;
+  }
+`
 
 export function NewEntityButton(props: {
   type?: string
@@ -66,38 +77,31 @@ export function NewEntityButton(props: {
         width={'600px'}
         height={'370px'}
       >
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            justifyContent: 'space-between',
-            margin: '20px',
-            minHeight: '270px',
-          }}
-        >
-          <div style={{ display: 'block' }}>
-            <Label label={'Blueprint'} />
-            <BlueprintPicker
-              disabled={!!copyTarget || !!type}
-              onChange={(selectedType: string) => setTypeToCreate(selectedType)}
-              formData={typeToCreate}
-            />
-            {!!copyTarget && (
-              <div
-                style={{ marginLeft: '40px' }}
-              >{`Copying entity named '${copyTarget.name}'`}</div>
-            )}
-          </div>
-          <div>
-            <Label label={'Entity destination folder'} />
-            <DestinationPicker
-              onChange={(selectedFolder: string) =>
-                setSaveDestination(selectedFolder)
-              }
-              disabled={!!defaultDestination}
-              formData={saveDestination}
-            />
-          </div>
+        <DialogWrapper>
+          {!!!type && (
+            <div style={{ display: 'block' }}>
+              <Label label={'Blueprint'} />
+              <BlueprintPicker
+                disabled={!!copyTarget}
+                onChange={(selectedType: string) =>
+                  setTypeToCreate(selectedType)
+                }
+                formData={typeToCreate}
+              />
+            </div>
+          )}
+
+          {!!!defaultDestination && (
+            <div>
+              <Label label={'Entity destination folder'} />
+              <DestinationPicker
+                onChange={(selectedFolder: string) =>
+                  setSaveDestination(selectedFolder)
+                }
+                formData={saveDestination}
+              />
+            </div>
+          )}
           <Label label={'Name'} />
           <Input
             style={{
@@ -109,6 +113,9 @@ export function NewEntityButton(props: {
             onChange={(event) => setNewName(event.target.value)}
             placeholder="Name for new entity"
           />
+          {!!copyTarget && (
+            <div>{`Copying entity named '${copyTarget.name}'`}</div>
+          )}
           <div
             style={{
               display: 'flex',
@@ -140,6 +147,7 @@ export function NewEntityButton(props: {
               type="submit"
               onClick={() => {
                 setLoading(true)
+
                 if (copyTarget) {
                   // @ts-ignore
                   delete copyTarget._id
@@ -147,7 +155,11 @@ export function NewEntityButton(props: {
 
                   addEntityToPath({ ...copyTarget })
                     .then(() => setShowScrim(false))
-                    .finally(() => setLoading(false))
+                    .finally(() => {
+                      setCopyTarget(undefined)
+                      setNewName('')
+                      setLoading(false)
+                    })
                 } else {
                   dmtAPI
                     .createEntity(typeToCreate, newName)
@@ -156,14 +168,18 @@ export function NewEntityButton(props: {
                         setShowScrim(false)
                       )
                     })
-                    .finally(() => setLoading(false))
+                    .finally(() => {
+                      setLoading(false)
+                      setCopyTarget(undefined)
+                      setNewName('')
+                    })
                 }
               }}
             >
               {loading ? <Progress.Dots /> : 'Create'}
             </Button>
           </div>
-        </div>
+        </DialogWrapper>
       </Dialog>
     </div>
   )

--- a/web/packages/plugins/shared/common/src/components/Pickers/BlueprintPicker.tsx
+++ b/web/packages/plugins/shared/common/src/components/Pickers/BlueprintPicker.tsx
@@ -20,7 +20,9 @@ export const BlueprintPicker = (props: {
 
   return (
     <div>
-      <Tooltip title={truncatePathString(formData)}>
+      <Tooltip
+        title={truncatePathString(formData) === formData ? '' : formData}
+      >
         <Input
           disabled={disabled}
           variant={variant || 'default'}

--- a/web/packages/plugins/shared/common/src/components/Pickers/DestinationPicker.tsx
+++ b/web/packages/plugins/shared/common/src/components/Pickers/DestinationPicker.tsx
@@ -19,10 +19,11 @@ import styled from 'styled-components'
 export type DestinationPickerProps = {
   onChange: (value: any) => void
   formData: any
+  disabled?: boolean
 }
 
 export const DestinationPicker = (props: DestinationPickerProps) => {
-  const { onChange, formData } = props
+  const { onChange, formData, disabled } = props
   const { treeNodes, loading } = useContext(FSTreeContext)
   const [showModal, setShowModal] = useState<boolean>(false)
 
@@ -41,6 +42,7 @@ export const DestinationPicker = (props: DestinationPickerProps) => {
             width: PATH_INPUT_FIELD_WIDTH,
             cursor: 'pointer',
           }}
+          disabled={disabled || false}
           type="string"
           value={truncatePathString(formData)}
           onChange={() => {}}

--- a/web/packages/plugins/ui/task/src/EditTask.tsx
+++ b/web/packages/plugins/ui/task/src/EditTask.tsx
@@ -58,7 +58,7 @@ export const EditTask = (props: DmtUIPlugin) => {
   }
   return (
     <div>
-      <div style={{ marginBottom: '10px' }}>
+      <div style={{ marginBottom: '0px' }}>
         <HeaderWrapper>
           <Typography variant="h3">Input</Typography>
           <GroupWrapper>

--- a/web/packages/plugins/ui/task/src/EditTask.tsx
+++ b/web/packages/plugins/ui/task/src/EditTask.tsx
@@ -9,6 +9,7 @@ import {
   EntityPickerButton,
   INPUT_FIELD_WIDTH,
   Loading,
+  DestinationPicker,
 } from '@dmt/common'
 import * as React from 'react'
 import { useEffect, useState } from 'react'
@@ -43,6 +44,7 @@ export const EditTask = (props: DmtUIPlugin) => {
   )
 
   const [formData, setFormData] = useState<any>()
+  const [entityDestination, setEntityDestination] = useState<string>('')
   const runnerTypeHasChanged =
     formData?.runner?.type && formData?.runner?.type === document?.runner?.type
   useEffect(() => {
@@ -67,6 +69,15 @@ export const EditTask = (props: DmtUIPlugin) => {
                   setFormData({ ...formData, inputType: selectedBlueprint })
                 }
                 formData={formData?.inputType || ''}
+              />
+            </Column>
+            <Column>
+              <Label label={'Entity destination folder'} />
+              <DestinationPicker
+                onChange={(selectedFolder: string) =>
+                  setEntityDestination(selectedFolder)
+                }
+                formData={entityDestination}
               />
             </Column>
             <div
@@ -115,6 +126,7 @@ export const EditTask = (props: DmtUIPlugin) => {
               />
               <NewEntityButton
                 type={formData.inputType}
+                defaultDestination={entityDestination}
                 setReference={(createdEntity: TReference) => {
                   setFormData({
                     ...formData,


### PR DESCRIPTION
## What does this pull request change?
* add an entity destination input to EditTask. This selection is used in the NewEntityButton.tsx.
* If a entity destination and/or blueprint is selected in EditTask, then the input fields for entity destination and blueprint are hidden in the "new entity button popup"
* Change order of input fields in NewEntityButton.tsx, such that the order is consistent with EditTask.tsx
* minor improvements: fix tooltip for blueprint selector and check type when copying existing entity in NewEntityButton.tsx



![image](https://user-images.githubusercontent.com/69512295/173790073-9e7454f5-d6f6-4b13-b618-e9535d26732e.png)
![image](https://user-images.githubusercontent.com/69512295/174626859-afc12afc-148d-4a07-9656-c84276f2005a.png)

## Why is this pull request needed?


## Issues related to this change
closes #1271

