### PR TITLE
feat: create Tree from folder. 

### DIFF
--- a/api/src/home/analysis-platform/data/AnalysisPlatformDS/Blueprints/SIMAApplicationInput.json
+++ b/api/src/home/analysis-platform/data/AnalysisPlatformDS/Blueprints/SIMAApplicationInput.json
@@ -27,6 +27,12 @@
       "contained": false
     },
     {
+      "type": "system/SIMOS/BlueprintAttribute",
+      "name": "inputPresetFolder",
+      "description": "Path to a folder inputs can be selected from",
+      "attributeType": "string"
+    },
+    {
       "name": "SIMAComputeConfig",
       "attributeType": "system/SIMOS/Blob",
       "type": "system/SIMOS/BlueprintAttribute",

--- a/api/src/home/analysis-platform/data/AnalysisPlatformDS/Data/sima_test/ULS_Intact.json
+++ b/api/src/home/analysis-platform/data/AnalysisPlatformDS/Data/sima_test/ULS_Intact.json
@@ -5,6 +5,7 @@
   "type": "AnalysisPlatformDS/Blueprints/SIMAApplicationInput",
   "inputType": "app_mooring_db/simpos/mooringSRS/MooringSRS",
   "outputType": "sima/marmo/report/ReportFragment",
+  "inputPresetFolder": "app_asgardb_db/SRS",
   "input": {
     "_id": "6683c9b0-d505-46c9-a157-94c79f4d7a6a",
     "type": "app_mooring_db/simpos/mooringSRS/MooringSRS",

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -47,8 +47,8 @@ services:
     image: web-dev
     stdin_open: true
     volumes:
-      - ./web/packages/home/src:/code/packages/home/src
-      - ./web/packages/plugins:/code/packages/plugins
+      - ./web/packages:/code/packages
+
     environment:
       - NODE_ENV=development
     networks:

--- a/web/packages/plugins/shared/common/src/components/TreeView.tsx
+++ b/web/packages/plugins/shared/common/src/components/TreeView.tsx
@@ -134,8 +134,8 @@ export const TreeView = (props: {
   useEffect(() => {
     let expandedNodes: { [k: string]: boolean } = {}
     nodes.forEach((node: TreeNode) => {
-      // Initialize expanded state where only top level DataSources are expanded
-      expandedNodes[node.nodeId] = node.isDataSource
+      // Initialize expanded state where only top level nodes are expanded
+      expandedNodes[node.nodeId] = node.level === 0
     })
     setExpandedNodes(expandedNodes)
   }, [])

--- a/web/packages/plugins/shared/common/src/context/FileSystemTreeContext.tsx
+++ b/web/packages/plugins/shared/common/src/context/FileSystemTreeContext.tsx
@@ -24,14 +24,15 @@ export const FSTreeProvider = (props: { children: ReactNode }) => {
 
   const tree: Tree = new Tree(
     token,
-    appConfig.visibleDataSources,
     // @ts-ignore
     (t: Tree) => setTreeNodes([...t])
   )
 
   useEffect(() => {
     setLoading(true)
-    tree.init().finally(() => setLoading(false))
+    tree
+      .initFromDataSources(appConfig.visibleDataSources)
+      .finally(() => setLoading(false))
   }, [])
 
   return (

--- a/web/packages/plugins/ui/sima-application-input/src/EditSimaApplicationInput.tsx
+++ b/web/packages/plugins/ui/sima-application-input/src/EditSimaApplicationInput.tsx
@@ -78,6 +78,13 @@ export const EditSimaApplicationInput = (props: DmtUIPlugin) => {
                 formData={formData?.inputType || ''}
               />
             </Column>
+            <Label label={'Folder presented for input selection'} />
+            <DestinationPicker
+              onChange={(presetFolder: string) =>
+                setFormData({ ...formData, inputPresetFolder: presetFolder })
+              }
+              formData={formData?.inputPresetFolder}
+            />
             <EditInputEntity
               formData={formData}
               setFormData={setFormData}

--- a/web/packages/plugins/ui/sima-application-input/src/components.tsx
+++ b/web/packages/plugins/ui/sima-application-input/src/components.tsx
@@ -10,8 +10,7 @@ import * as React from 'react'
 import styled from 'styled-components'
 
 export const HeaderWrapper = styled.div`
-  margin-bottom: 50px;
-  margin-top: 8px;
+  margin: 8px 0;
 `
 export const Column = styled.div``
 
@@ -33,7 +32,7 @@ export function EditInputEntity(props: {
   const { formData, setFormData, dataSourceId, onOpen } = props
 
   return (
-    <HeaderWrapper>
+    <div>
       <div style={{ display: 'flex', alignItems: 'flex-end' }}>
         <Column>
           <Label label={'Input entity'} />
@@ -65,6 +64,7 @@ export function EditInputEntity(props: {
               input: selectedEntity,
             })
           }
+          scope={formData?.inputPresetFolder}
         />
         <NewEntityButton
           type={formData?.inputType || ''}
@@ -93,6 +93,6 @@ export function EditInputEntity(props: {
           )}
         </div>
       )}
-    </HeaderWrapper>
+    </div>
   )
 }


### PR DESCRIPTION
## What does this pull request change?
- A new method to init a Tree, "initFromFolder"
- DestinationPicker and EntitySelector now takes a "scope" param and will use the new Tree init method if provided
- Blueprint and plugin updated for SIMAApplicationInput, providing a "presetInputFolder"


![anno2](https://user-images.githubusercontent.com/11062560/176625333-ab2706c8-bea6-402a-beed-689577a5e25e.png)
![Screenshot_20220630_100217](https://user-images.githubusercontent.com/11062560/176625351-9cd280ce-4968-4b09-b55c-9ff73a51aa8f.png)



## Why is this pull request needed?
- Some simpler views should not be able to see the whole tree structure on some operations

## Issues related to this change
closes #1306 
