### PR TITLE
add secrets and env vars for role check feature

### DIFF
--- a/radixconfig.yaml
+++ b/radixconfig.yaml
@@ -95,6 +95,7 @@ spec:
       secrets:
         - MONGO_URI
         - SECRET_KEY
+        - OAUTH_CLIENT_SECRET
 
       variables:
         LOGGING_LEVEL: "debug"
@@ -105,6 +106,8 @@ spec:
         OAUTH_AUTH_ENDPOINT: https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/oauth2/v2.0/authorize
         OAUTH_CLIENT_ID: 97a6b5bd-63fb-42c6-bb75-7e5de2394ba0
         OAUTH_AUDIENCE: 97a6b5bd-63fb-42c6-bb75-7e5de2394ba0
+        AAD_ENTERPRISE_APP_OID: b9041025-05f0-44d4-89a7-3b5f955c0de5
+        AUTH_PROVIDER_FOR_ROLE_CHECK: AAD
       ports:
         - name: rest
           port: 5000


### PR DESCRIPTION
## What does this pull request change?
- `radixconfig.yml`: Adds a `secret` and two environment variables to the DMSS component relating to the new PAT role checker feature (equinor/data-modelling-storage-service/issues/188)

## Why is this pull request needed?

## Issues related to this change
- equinor/data-modelling-storage-service/issues/188

