### PR TITLE
feat: job_service now works with uid's. This makes jobs deletable

### DIFF
--- a/api/src/features/jobs/jobs.py
+++ b/api/src/features/jobs/jobs.py
@@ -4,7 +4,7 @@ from features.jobs.use_cases.delete_job import delete_job_use_case
 from features.jobs.use_cases.get_result_job import get_job_result_use_case, GetJobResultResponse
 from features.jobs.use_cases.status_job import status_job_use_case, StatusJobResponse
 from starlette.responses import JSONResponse, PlainTextResponse
-from features.jobs.use_cases.start_job import start_job_use_case
+from features.jobs.use_cases.start_job import start_job_use_case, StartJobResponse
 from restful.responses import create_response
 
 router = APIRouter(tags=["DMT", "Jobs"], prefix="/job")
@@ -15,33 +15,33 @@ job_service_disabled_error = (
 )
 
 
-@router.post("/{job_id:path}", operation_id="start_job")
-@create_response(PlainTextResponse)
-def start(job_id: str):
-    if not config.JOB_SERVICE_ENABLED:
-        raise Exception(job_service_disabled_error)
-    return start_job_use_case(job_id=job_id)
-
-
-@router.get("/{job_id:path}", operation_id="job_status", response_model=StatusJobResponse)
+@router.post("/{job_dmss_id:path}", operation_id="start_job", response_model=StartJobResponse)
 @create_response(JSONResponse)
-def status(job_id: str):
+def start(job_dmss_id: str):
     if not config.JOB_SERVICE_ENABLED:
         raise Exception(job_service_disabled_error)
-    return status_job_use_case(job_id=job_id).dict()
+    return start_job_use_case(job_dmss_id=job_dmss_id).dict()
 
 
-@router.delete("/{job_id:path}", operation_id="remove_job")
-@create_response(PlainTextResponse)
-def remove(job_id: str):
-    if not config.JOB_SERVICE_ENABLED:
-        raise Exception(job_service_disabled_error)
-    return delete_job_use_case(job_id=job_id)
-
-
-@router.get("/{job_id:path}/result", operation_id="job_result", response_model=GetJobResultResponse)
+@router.get("/{job_uid}", operation_id="job_status", response_model=StatusJobResponse)
 @create_response(JSONResponse)
-def result(job_id: str):
+def status(job_uid: str):
     if not config.JOB_SERVICE_ENABLED:
         raise Exception(job_service_disabled_error)
-    return get_job_result_use_case(job_id=job_id).dict()
+    return status_job_use_case(job_id=job_uid).dict()
+
+
+@router.delete("/{job_uid}", operation_id="remove_job")
+@create_response(PlainTextResponse)
+def remove(job_uid: str):
+    if not config.JOB_SERVICE_ENABLED:
+        raise Exception(job_service_disabled_error)
+    return delete_job_use_case(job_id=job_uid)
+
+
+@router.get("/{job_uid}/result", operation_id="job_result", response_model=GetJobResultResponse)
+@create_response(JSONResponse)
+def result(job_uid: str):
+    if not config.JOB_SERVICE_ENABLED:
+        raise Exception(job_service_disabled_error)
+    return get_job_result_use_case(job_uid=job_uid).dict()

--- a/api/src/features/jobs/use_cases/get_result_job.py
+++ b/api/src/features/jobs/use_cases/get_result_job.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from services.job_service import JobService
 from pydantic import BaseModel
 
@@ -7,7 +9,7 @@ class GetJobResultResponse(BaseModel):
     result: str
 
 
-def get_job_result_use_case(job_id: str) -> GetJobResultResponse:
+def get_job_result_use_case(job_uid: str) -> GetJobResultResponse:
     job_service = JobService()
-    message, bytesvalue = job_service.get_job_result(job_id)
+    message, bytesvalue = job_service.get_job_result(UUID(job_uid))
     return GetJobResultResponse(**{"message": message, "result": bytesvalue.decode("UTF-8")})

--- a/api/src/features/jobs/use_cases/start_job.py
+++ b/api/src/features/jobs/use_cases/start_job.py
@@ -1,7 +1,16 @@
+from typing import Tuple
+
+from pydantic.main import BaseModel
+
 from services.job_service import JobService
 
 
-def start_job_use_case(job_id: str) -> str:
+class StartJobResponse(BaseModel):
+    message: str
+    uid: str
+
+
+def start_job_use_case(job_dmss_id: str) -> StartJobResponse:
     job_service = JobService()
-    result: str = job_service.register_job(job_id)
-    return result
+    result: Tuple[str, str] = job_service.register_job(job_dmss_id)
+    return StartJobResponse(**{"message": result[1], "uid": result[0]})

--- a/api/src/features/jobs/use_cases/status_job.py
+++ b/api/src/features/jobs/use_cases/status_job.py
@@ -1,5 +1,7 @@
-from services.job_service import JobService
+from uuid import UUID
+
 from services.job_handler_interface import JobStatus
+from services.job_service import JobService
 from pydantic import BaseModel
 
 
@@ -8,8 +10,11 @@ class StatusJobResponse(BaseModel):
     log: str | None
     message: str
 
+    class Config:
+        use_enum_values = True
+
 
 def status_job_use_case(job_id: str) -> StatusJobResponse:
     job_service = JobService()
-    status, log, message = job_service.status_job(job_id)
+    status, log, message = job_service.status_job(UUID(job_id))
     return StatusJobResponse(**{"status": status.value, "log": log, "message": message})

--- a/api/src/home/analysis-platform/data/WorkflowDS/Blueprints/Job.json
+++ b/api/src/home/analysis-platform/data/WorkflowDS/Blueprints/Job.json
@@ -5,6 +5,12 @@
   "extends": ["system/SIMOS/NamedEntity", "system/SIMOS/DefaultUiRecipes"],
   "attributes": [
     {
+      "name": "uid",
+      "type": "system/SIMOS/BlueprintAttribute",
+      "attributeType": "string",
+      "optional": false
+    },
+    {
       "name": "label",
       "type": "system/SIMOS/BlueprintAttribute",
       "attributeType": "string",

--- a/api/src/home/analysis-platform/job_handlers/local_container/__init__.py
+++ b/api/src/home/analysis-platform/job_handlers/local_container/__init__.py
@@ -65,9 +65,12 @@ class JobHandler(JobHandlerInterface):
         logger.info("*** Local container job started successfully ***")
         return "Ok"
 
-    def remove(self) -> str:
-        container = self.client.containers.get(self.job.entity["name"])
-        container.remove()
+    def remove(self) -> Tuple[str, str]:
+        try:
+            container = self.client.containers.get(self.job.entity["name"])
+            container.remove()
+        except docker.errors.NotFound:
+            pass
         return JobStatus.REMOVED, "Removed"
 
     def progress(self) -> Tuple[JobStatus, str]:

--- a/api/src/init.sh
+++ b/api/src/init.sh
@@ -83,7 +83,12 @@ fi
 
 if [ "$1" = 'api' ]; then
   service_is_ready
-  gunicorn app:create_app --workers 4 --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:5000
+    if [ "$ENVIRON" != "local" ]; then
+    cat version.txt || true
+    gunicorn app:create_app --workers 4 --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:5000
+  else
+    python3 /code/app.py run
+  fi
 elif [ "$1" = 'behave' ]; then
   service_is_ready
   shift

--- a/web/packages/home/src/App.js
+++ b/web/packages/home/src/App.js
@@ -114,7 +114,9 @@ function App() {
         }}
       />
     )
-
+  if (!applications) {
+    return <>Error: Failed to fetch Application settings</>
+  }
   return (
     <ThemeProvider theme={theme}>
       <Router>

--- a/web/packages/plugins/shared/common/src/services/JobApi.ts
+++ b/web/packages/plugins/shared/common/src/services/JobApi.ts
@@ -11,19 +11,19 @@ export class JobApi {
     }
   }
 
-  startJob(jobId: string) {
-    return axios.post(`${this.jobUrl}/${jobId}`, null, this.requestConfig)
+  startJob(jobDMSSPath: string) {
+    return axios.post(`${this.jobUrl}/${jobDMSSPath}`, null, this.requestConfig)
   }
 
-  statusJob(jobId: string) {
-    return axios.get(`${this.jobUrl}/${jobId}`, this.requestConfig)
+  statusJob(jobUID: string) {
+    return axios.get(`${this.jobUrl}/${jobUID}`, this.requestConfig)
   }
 
-  removeJob(jobId: string) {
-    return axios.delete(`${this.jobUrl}/${jobId}`, this.requestConfig)
+  removeJob(jobUID: string) {
+    return axios.delete(`${this.jobUrl}/${jobUID}`, this.requestConfig)
   }
 
-  result(jobId: string) {
-    return axios.get(`${this.jobUrl}/${jobId}/result`, this.requestConfig)
+  result(jobUID: string) {
+    return axios.get(`${this.jobUrl}/${jobUID}/result`, this.requestConfig)
   }
 }

--- a/web/packages/plugins/shared/common/src/types.ts
+++ b/web/packages/plugins/shared/common/src/types.ts
@@ -92,6 +92,7 @@ export type TJob = {
   applicationInput: TReference
   runner: TJobHandler | TContainerJobHandler
   started: string
+  uid?: string
   result?: any
   ended?: string
   outputTarget?: string

--- a/web/packages/plugins/ui/analysis/src/InspectorView.tsx
+++ b/web/packages/plugins/ui/analysis/src/InspectorView.tsx
@@ -35,7 +35,7 @@ export const InspectorView = (props: DmtUIPlugin): JSX.Element => {
         jobs={jobs}
         analysisId={analysis._id}
         dataSourceId={dataSourceId}
-        setJobs={() => {}}
+        setJobs={() => undefined}
       />
     </>
   )

--- a/web/packages/plugins/ui/analysis/src/InspectorView.tsx
+++ b/web/packages/plugins/ui/analysis/src/InspectorView.tsx
@@ -35,6 +35,7 @@ export const InspectorView = (props: DmtUIPlugin): JSX.Element => {
         jobs={jobs}
         analysisId={analysis._id}
         dataSourceId={dataSourceId}
+        setJobs={() => {}}
       />
     </>
   )

--- a/web/packages/plugins/ui/analysis/src/OperatorView.tsx
+++ b/web/packages/plugins/ui/analysis/src/OperatorView.tsx
@@ -51,6 +51,7 @@ export const OperatorView = (props: DmtUIPlugin): JSX.Element => {
           jobs={jobs}
           analysisId={analysis._id}
           dataSourceId={dataSourceId}
+          setJobs={setJobs}
         />
       </>
     </>

--- a/web/packages/plugins/ui/job/src/JobControl.tsx
+++ b/web/packages/plugins/ui/job/src/JobControl.tsx
@@ -99,7 +99,7 @@ export const JobControl = (props: {
       })
       .catch((error: AxiosError<any>) => {
         if (error.response) {
-          setJobLogs(error.response.data?.message || error.message)
+          setJobLogs(error.response.data || error.message)
           setJobStatus(document.status)
         } else setJobLogs('Error occurred when getting status for job')
 


### PR DESCRIPTION
## What does this pull request change?
- JobService now works with UID for started jobs
- Enable delete button on "AnalysisJobTable"

## Why is this pull request needed?
- Should be possible to delete jobs

## Issues related to this change
closes #1313 
