### PR TITLE
Analysis navigation and clickable breadcrumbs

### DIFF
--- a/api/src/services/job_service.py
+++ b/api/src/services/job_service.py
@@ -2,14 +2,12 @@ import importlib
 import json
 from datetime import datetime
 from pathlib import Path
-from time import sleep
 from typing import Callable, Tuple, Union
 import redis
 import traceback
 
 import requests
 from redis import AuthenticationError
-from requests import HTTPError
 
 from config import config
 from enums import SIMOS
@@ -153,10 +151,13 @@ class JobService:
                 raise error
         except NotImplementedError as error:
             job.log = (
-                f"{job.log}\n\n The jobHandler '{type(job_handler).__name__}' is missing some implementations: {error}"
+                f"{job.log}\n\nThe jobHandler '{type(job_handler).__name__}' is missing some implementations: {error}"
             )
         except KeyError as error:
-            job.log = f"{job.log}\n\n The jobHandler '{type(job_handler).__name__}' tried to access a missing attribute: {error}"
+            job.log = (
+                f"{job.log}\n\nThe jobHandler '{type(job_handler).__name__}' "
+                f"tried to access a missing attribute: {error}"
+            )
         except Exception as error:
             job.log = f"{job.log}\n\n {error}"
         finally:

--- a/web/packages/plugins/apps/analysis-platform/src/components/Design/Colors.ts
+++ b/web/packages/plugins/apps/analysis-platform/src/components/Design/Colors.ts
@@ -7,3 +7,5 @@ export const backgroundColorLight = colors.ui.background__light.rgba
 export const primary = colors.infographic.primary__moss_green_100.rgba
 export const primaryGray = '#f7f7f7'
 export const lightGray = '#f6f6f6'
+export const linkPrimary = colors.interactive.primary__resting.rgba
+export const linkHoverPrimary = colors.interactive.primary__hover.rgba

--- a/web/packages/plugins/apps/analysis-platform/src/components/Layout/Content.tsx
+++ b/web/packages/plugins/apps/analysis-platform/src/components/Layout/Content.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { Layout } from 'antd'
 import styled from 'styled-components'
+import { useParams } from 'react-router-dom'
 
-import { TContent } from '@dmt/common'
+import { TContent, DocumentPath } from '@dmt/common'
 import { backgroundColorDefault, backgroundColorLight } from '../Design/Colors'
 
 const { Content } = Layout
@@ -14,9 +15,16 @@ const PageContent = styled.div`
 
 export default (props: TContent): JSX.Element => {
   const { content } = props
+  const { data_source, entity_id } = useParams<{
+    data_source: string
+    entity_id: string
+  }>()
 
   return (
     <Content style={{ margin: '0px 0px 10px 0px' }}>
+      {data_source && entity_id && (
+        <DocumentPath absoluteDottedId={`${data_source}/${entity_id}`} />
+      )}
       {/*@ts-ignore*/}
       <PageContent>{content({ settings: props.settings })}</PageContent>
     </Content>

--- a/web/packages/plugins/shared/common/src/components/UiPluginSelector.tsx
+++ b/web/packages/plugins/shared/common/src/components/UiPluginSelector.tsx
@@ -33,6 +33,14 @@ const PathWrapper = styled.div`
   overflow: hidden;
 `
 
+const PathPartLink = styled.a`
+  color: #007079;
+  &:hover {
+    color: #004f55;
+    font-weight: bold;
+  }
+`
+
 const PathPart = styled.div`
   margin-top: 0;
   margin-right: 15px;
@@ -60,7 +68,10 @@ export function DocumentPath(props: { absoluteDottedId: string }): JSX.Element {
         return (
           <div style={{ display: 'flex', flexWrap: 'nowrap' }} key={part}>
             {index !== 0 && <PathPart>/</PathPart>}
-            <PathPart as="a" href={getHref(dataSource, parts, index)}>
+            <PathPart
+              as={PathPartLink}
+              href={getHref(dataSource, parts, index)}
+            >
               {part}
             </PathPart>
           </div>

--- a/web/packages/plugins/shared/common/src/components/UiPluginSelector.tsx
+++ b/web/packages/plugins/shared/common/src/components/UiPluginSelector.tsx
@@ -38,16 +38,31 @@ const PathPart = styled.div`
   margin-right: 15px;
 `
 
+const getHref = (
+  dataSource: string,
+  parts: string[],
+  index: number
+): string => {
+  // Get the HREF for the document
+  return parts
+    .slice(0, index + 1)
+    .join('.')
+    .replace(`${dataSource}/`, '')
+}
+
 export function DocumentPath(props: { absoluteDottedId: string }): JSX.Element {
   const { absoluteDottedId } = props
   const parts = absoluteDottedId.split('.')
+  const dataSource = absoluteDottedId.split('/')[0]
   return (
     <PathWrapper>
       {parts.map((part: string, index: number) => {
         return (
           <div style={{ display: 'flex', flexWrap: 'nowrap' }} key={part}>
             {index !== 0 && <PathPart>/</PathPart>}
-            <PathPart>{part}</PathPart>
+            <PathPart as="a" href={getHref(dataSource, parts, index)}>
+              {part}
+            </PathPart>
           </div>
         )
       })}


### PR DESCRIPTION
## What does this pull request change?
- Adds an `<a href={absoluteDottedId}/>` to each part of the `<DocumentPath />` (breadcrumb) to allow for navigation by clicking the respective parts of the breadcrumb
- Adds a clickable breadcrumb above the page content (below the header), visible when viewing any document
- Some minor fixes to `job_service.py` due to complaints from the pre-commit pipeline (unused imports, line length)

**Dashboard** (no breadcrumb, as no document is in view)
![2022-08-02_11-11](https://user-images.githubusercontent.com/16702264/182339275-7634f6af-bb62-47a8-8d65-6b712bf26a85.png)

**Analysis view**
![2022-08-02_11-07](https://user-images.githubusercontent.com/16702264/182339452-33a6944c-3041-4366-ac52-9f2f08dc2bc8.png)

**Job view**
![2022-08-02_11-08](https://user-images.githubusercontent.com/16702264/182339549-2042baaa-c5a9-416d-bcb8-793ed6058648.png)

**Application input view**
![2022-08-02_11-08_1](https://user-images.githubusercontent.com/16702264/182339611-810e8333-94ef-42a7-91d3-7bac2a1eaa4d.png)



## Why is this pull request needed?
- To facilitate easier navigation when viewing analyses in the Analysis Platform
- To support clickable breadcrumbs in the existing `<DocumentPath />` component

## Issues related to this change
- Resolves #1148 
- Relates to #1201 