### PR TITLE
Fix overflowing actions in the `AnalysisCard` component

### DIFF
--- a/api/src/services/job_service.py
+++ b/api/src/services/job_service.py
@@ -2,14 +2,12 @@ import importlib
 import json
 from datetime import datetime
 from pathlib import Path
-from time import sleep
 from typing import Callable, Tuple, Union
 import redis
 import traceback
 
 import requests
 from redis import AuthenticationError
-from requests import HTTPError
 
 from config import config
 from enums import SIMOS
@@ -153,10 +151,13 @@ class JobService:
                 raise error
         except NotImplementedError as error:
             job.log = (
-                f"{job.log}\n\n The jobHandler '{type(job_handler).__name__}' is missing some implementations: {error}"
+                f"{job.log}\n\nThe jobHandler '{type(job_handler).__name__}' is missing some implementations: {error}"
             )
         except KeyError as error:
-            job.log = f"{job.log}\n\n The jobHandler '{type(job_handler).__name__}' tried to access a missing attribute: {error}"
+            job.log = (
+                f"{job.log}\n\nThe jobHandler '{type(job_handler).__name__}' "
+                f"tried to access a missing attribute: {error}"
+            )
         except Exception as error:
             job.log = f"{job.log}\n\n {error}"
         finally:

--- a/web/packages/plugins/ui/analysis/src/components/AnalysisCard.tsx
+++ b/web/packages/plugins/ui/analysis/src/components/AnalysisCard.tsx
@@ -35,7 +35,7 @@ const CardWrapper = styled.div`
   width: 400px;
   box-sizing: border-box;
   display: grid;
-  grid-template-columns: repeat(2, 320px);
+  grid-template-columns: repeat(1, auto);
   grid-gap: 32px 32px;
   border-radius: 5px;
 `


### PR DESCRIPTION
## What does this pull request change?
- Changes the `CardWrapper` styled component's `grid-template-columns` to `1` (a single column) with `auto`, rather than `2` with a hard-coded size (`320px`) to ensure that all children are contained in the wrapper.

## Why is this pull request needed?
The `AnalysisCard` component's `Card.Actions` are overflowing (with the exception of Inspectors and Operators, due to fewer buttons being displayed).

Current:
![2022-08-02_10-20](https://user-images.githubusercontent.com/16702264/182359024-ce8ec7cd-e214-4e81-9bc3-26ec4fc4decc.png)

Fixed by this PR:
![2022-08-02_12-49](https://user-images.githubusercontent.com/16702264/182359058-41af06b4-8c42-4f75-ad24-ab21a99e7c5d.png)

## Issues related to this change
- Resolves #1334 
