### PR TITLE
fix DMSS authentication bug

### DIFF
--- a/web/packages/dmt-core/src/services/api/configs/gen-dmt/api/dmtapi.ts
+++ b/web/packages/dmt-core/src/services/api/configs/gen-dmt/api/dmtapi.ts
@@ -342,6 +342,15 @@ export const DMTApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
+      // authentication OAuth2AuthorizationCodeBearer required
+      // oauth required
+      await setOAuthToObject(
+        localVarHeaderParameter,
+        'OAuth2AuthorizationCodeBearer',
+        [],
+        configuration
+      )
+
       setSearchParams(localVarUrlObj, localVarQueryParameter, options.query)
       let headersFromBaseOptions =
         baseOptions && baseOptions.headers ? baseOptions.headers : {}
@@ -388,6 +397,15 @@ export const DMTApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
+      // authentication OAuth2AuthorizationCodeBearer required
+      // oauth required
+      await setOAuthToObject(
+        localVarHeaderParameter,
+        'OAuth2AuthorizationCodeBearer',
+        [],
+        configuration
+      )
+
       setSearchParams(localVarUrlObj, localVarQueryParameter, options.query)
       let headersFromBaseOptions =
         baseOptions && baseOptions.headers ? baseOptions.headers : {}
@@ -433,6 +451,15 @@ export const DMTApiAxiosParamCreator = function (
       }
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
+
+      // authentication OAuth2AuthorizationCodeBearer required
+      // oauth required
+      await setOAuthToObject(
+        localVarHeaderParameter,
+        'OAuth2AuthorizationCodeBearer',
+        [],
+        configuration
+      )
 
       setSearchParams(localVarUrlObj, localVarQueryParameter, options.query)
       let headersFromBaseOptions =
@@ -516,6 +543,15 @@ export const DMTApiAxiosParamCreator = function (
       }
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
+
+      // authentication OAuth2AuthorizationCodeBearer required
+      // oauth required
+      await setOAuthToObject(
+        localVarHeaderParameter,
+        'OAuth2AuthorizationCodeBearer',
+        [],
+        configuration
+      )
 
       setSearchParams(localVarUrlObj, localVarQueryParameter, options.query)
       let headersFromBaseOptions =

--- a/web/packages/dmt-core/src/services/api/configs/gen-dmt/api/jobs-api.ts
+++ b/web/packages/dmt-core/src/services/api/configs/gen-dmt/api/jobs-api.ts
@@ -84,6 +84,15 @@ export const JobsApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
+      // authentication OAuth2AuthorizationCodeBearer required
+      // oauth required
+      await setOAuthToObject(
+        localVarHeaderParameter,
+        'OAuth2AuthorizationCodeBearer',
+        [],
+        configuration
+      )
+
       setSearchParams(localVarUrlObj, localVarQueryParameter, options.query)
       let headersFromBaseOptions =
         baseOptions && baseOptions.headers ? baseOptions.headers : {}
@@ -129,6 +138,15 @@ export const JobsApiAxiosParamCreator = function (
       }
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
+
+      // authentication OAuth2AuthorizationCodeBearer required
+      // oauth required
+      await setOAuthToObject(
+        localVarHeaderParameter,
+        'OAuth2AuthorizationCodeBearer',
+        [],
+        configuration
+      )
 
       setSearchParams(localVarUrlObj, localVarQueryParameter, options.query)
       let headersFromBaseOptions =
@@ -176,6 +194,15 @@ export const JobsApiAxiosParamCreator = function (
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
 
+      // authentication OAuth2AuthorizationCodeBearer required
+      // oauth required
+      await setOAuthToObject(
+        localVarHeaderParameter,
+        'OAuth2AuthorizationCodeBearer',
+        [],
+        configuration
+      )
+
       setSearchParams(localVarUrlObj, localVarQueryParameter, options.query)
       let headersFromBaseOptions =
         baseOptions && baseOptions.headers ? baseOptions.headers : {}
@@ -221,6 +248,15 @@ export const JobsApiAxiosParamCreator = function (
       }
       const localVarHeaderParameter = {} as any
       const localVarQueryParameter = {} as any
+
+      // authentication OAuth2AuthorizationCodeBearer required
+      // oauth required
+      await setOAuthToObject(
+        localVarHeaderParameter,
+        'OAuth2AuthorizationCodeBearer',
+        [],
+        configuration
+      )
 
       setSearchParams(localVarUrlObj, localVarQueryParameter, options.query)
       let headersFromBaseOptions =


### PR DESCRIPTION
## What does this pull request change?
add security dependecy to the dmt fastapi for job API, to update the openapi schema. 
There was a bug where the requests to job api from dmt web did not include the access token. This caused an auth error in the job api, since the job api use the dmss python package.   

This solution feels a bit hacky, so I am very open to other suggestions for how to fix this. 
I could not find any other way to simple way to solve this.

## Why is this pull request needed?
auth error when using the job api
## Issues related to this change
closes #1385 

